### PR TITLE
Fix: ignore commented lines when parsing parafile

### DIFF
--- a/flowtorch/data/tau_dataloader.py
+++ b/flowtorch/data/tau_dataloader.py
@@ -84,7 +84,7 @@ class TAUConfig(object):
         value = ""
         for line in self._file_content:
             if parameter in line:
-                if not '#' in line.split(CONFIG_SEP)[0]:
+                if not COMMENT_CHAR in line.split(CONFIG_SEP)[0]:
                     value = line.split(CONFIG_SEP)[-1].split(COMMENT_CHAR)[0].strip()
         return value
 

--- a/flowtorch/data/tau_dataloader.py
+++ b/flowtorch/data/tau_dataloader.py
@@ -84,7 +84,8 @@ class TAUConfig(object):
         value = ""
         for line in self._file_content:
             if parameter in line:
-                value = line.split(CONFIG_SEP)[-1].split(COMMENT_CHAR)[0].strip()
+                if not '#' in line.split(CONFIG_SEP)[0]:
+                    value = line.split(CONFIG_SEP)[-1].split(COMMENT_CHAR)[0].strip()
         return value
 
     def _parse_bmap(self) -> dict:


### PR DESCRIPTION
There was a minor problem in the taudataloader when parsing the parameter file. Even if the line was just a comment (using the '#' char) the value was returned. This is now fixed.