### PR TITLE
Load weights (cell volumes) in TauDataloader from last snapshot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ flowTorch.egg-info
 datasets
 datasets_minimal
 compile_article
+flow

--- a/flowtorch/analysis/__init__.py
+++ b/flowtorch/analysis/__init__.py
@@ -10,3 +10,4 @@ from .svd import SVD
 from .svd import inexact_alm_matrix_completion
 from .linear_control import LinearControl
 from .linear_model import LinearModel
+from .dft import DFT, PDFT

--- a/flowtorch/analysis/dft.py
+++ b/flowtorch/analysis/dft.py
@@ -59,7 +59,7 @@ class DFT(object):
         :return: mode amplitudes (vector norm of the raw modes)
         :rtype: pt.Tensor
         """
-        return self._amplitude[1:] / sqrt(self._dm.shape[0])
+        return self._amplitude[1:]**2 / self._dm.shape[0]
 
     @property
     def frequency(self) -> pt.Tensor:
@@ -87,7 +87,7 @@ class DFT(object):
 
     @property
     def spectral_density(self) -> pt.Tensor:
-        return self.amplitude**2 / self.frequency
+        return self.amplitude / self.frequency
 
     @property
     def reconstruction(self) -> pt.Tensor:
@@ -129,6 +129,7 @@ class DFT(object):
     def top_modes(
         self,
         n: int = 1,
+        density: bool = True,
         f_min: float = -float("inf"),
         f_max: float = float("inf"),
     ) -> pt.Tensor:
@@ -136,6 +137,9 @@ class DFT(object):
 
         :param n: number of indices to return; defaults to 1
         :type n: int
+        :param density: sorting based on density rather than amplitudes;
+            defaults to True
+        :type density: bool, optional
         :param f_min: consider only modes with a frequency larger or equal
             to f_min; defaults to -inf
         :type f_min: float, optional
@@ -151,7 +155,8 @@ class DFT(object):
             modes_in_range
         ]
         n = min(n, mode_indices.shape[0])
-        top_n = self.amplitude[mode_indices].abs().topk(n).indices
+        imp = self.spectral_density if density else self.amplitude
+        top_n = imp[mode_indices].abs().topk(n).indices
         return mode_indices[top_n]
 
 
@@ -214,7 +219,7 @@ class PDFT(DFT):
         :return: amplitudes considering the size of the full state
         :rtype: pt.Tensor
         """
-        return super().amplitude * sqrt(self._dm.shape[0]) / sqrt(self._dm_org.shape[0])
+        return super().amplitude * self._dm.shape[0] / self._dm_org.shape[0]
 
     @property
     def modes(self) -> pt.Tensor:

--- a/flowtorch/analysis/dft.py
+++ b/flowtorch/analysis/dft.py
@@ -1,0 +1,233 @@
+"""Discrete Fourier transformations of snapshot data."""
+
+# standard library packages
+from typing import Set
+from math import sqrt
+
+# third party packages
+import torch as pt
+
+# flowtorch packages
+from .svd import SVD
+
+
+class DFT(object):
+    """Compute the discrete Fourier transform (DFT) of a data matrix."""
+
+    def __init__(
+        self,
+        data_matrix: pt.Tensor,
+        dt: float,
+        nfft: int | None = None,
+        device: str = "cpu",
+    ):
+        """Compute the discrete Fourier transform (DFT) of a data matrix.
+
+        The DFT is computed along the time axis of the data matrix (for every row).
+
+        :param data_matrix: M x N data matrix, where M is the number of spatial points
+            and N is the number of time instances
+        :type data_matrix: pt.Tensor
+        :param dt: timestep between snapshots; must be constant
+        :type dt: float
+        :param nfft: number of FFT frequency bin; zero-padding or truncation is
+            used if nfft > N or nfft < N, respectively, defaults to N
+        :type nfft: int | None, optional
+        :param device: device on which to perform the DFT, defaults to "cpu"
+        :type device: str, optional
+        """
+        self._dm = data_matrix
+        self._mean = data_matrix.mean(dim=-1)
+        self._dt = dt
+        self._nfft = nfft if nfft is not None else self._dm.shape[-1]
+        self._device = device
+        self._frequency = (
+            pt.fft.fftfreq(self._nfft, dt)
+            if pt.is_complex(self._dm)
+            else pt.fft.rfftfreq(self._nfft, dt)
+        )
+        fft = pt.fft.fft if pt.is_complex(self._dm) else pt.fft.rfft
+        self._modes = fft(
+            (self._dm - self._mean.unsqueeze(-1)).to(device), self._nfft, -1, "ortho"
+        ).cpu()
+        self._amplitude = self._modes.norm(dim=0)
+
+    @property
+    def amplitude(self) -> pt.Tensor:
+        """Vector norm of the spatial DFT modes.
+
+        :return: mode amplitudes (vector norm of the raw modes)
+        :rtype: pt.Tensor
+        """
+        return self._amplitude[1:] / sqrt(self._dm.shape[0])
+
+    @property
+    def frequency(self) -> pt.Tensor:
+        """Bin frequency values.
+
+        For real input data, the symmetric part of the spectrum is excluded.
+        The zero-frequency bin is always excluded since the data is mean-subtracted.
+
+        :return: frequency bin values
+        :rtype: pt.Tensor
+        """
+        return self._frequency[1:]
+
+    @property
+    def modes(self) -> pt.Tensor:
+        """Spatial DFT modes normalized to unit length.
+
+        The zero-frequency mode is exluded since the data
+        is mean-subtracted.
+
+        :return: complex, spatial DFT modes
+        :rtype: pt.Tensor
+        """
+        return self._modes[:, 1:] / self._amplitude[1:]
+
+    @property
+    def spectral_density(self) -> pt.Tensor:
+        return self.amplitude**2 / self.frequency
+
+    @property
+    def reconstruction(self) -> pt.Tensor:
+        """Compute the inverse DFT using all modes.
+
+        :return: reconstructed input data matrix
+        :rtype: pt.Tensor
+        """
+        return self.partial_reconstruction(set(range(len(self.amplitude))), True)
+
+    def partial_reconstruction(
+        self, mode_indices: Set[int] | int, include_mean: bool = False
+    ) -> pt.Tensor:
+        """Reconstruct the original data using selected modes.
+
+        :param mode_indices: mode indices to include in the reconstruction;
+            the zero-frequency bin is included by default but does not contribute
+            to the reconstruction since the data is mean-subtracted.
+        :type mode_indices: Set[int] | int
+        :param include_mean: add the mean to the reconstruction; can be useful for
+            animations, defaults to False
+        :type include_mean: bool, optional
+        :return: partial reconstruction of the input data matrix
+        :rtype: pt.Tensor
+        """
+        if isinstance(mode_indices, int):
+            mode_indices = {mode_indices}
+        indices = pt.tensor(list(mode_indices), dtype=pt.int64) + 1
+        mask = pt.zeros_like(self._amplitude).type(self._modes.dtype)
+        mask[0] = 1.0
+        mask[indices] = 1.0
+        options = ((self._modes * mask).to(self._device), self._nfft, -1, "ortho")
+        offset = self._mean.unsqueeze(-1) if include_mean else 0
+        if pt.is_complex(self._dm):
+            return pt.fft.ifft(*options).cpu() + offset
+        else:
+            return pt.fft.irfft(*options).cpu().real + offset
+
+    def top_modes(
+        self,
+        n: int = 1,
+        f_min: float = -float("inf"),
+        f_max: float = float("inf"),
+    ) -> pt.Tensor:
+        """Get the indices of the first n most important modes.
+
+        :param n: number of indices to return; defaults to 1
+        :type n: int
+        :param f_min: consider only modes with a frequency larger or equal
+            to f_min; defaults to -inf
+        :type f_min: float, optional
+        :param f_max: consider only modes with a frequency smaller than f_max;
+            defaults to -inf
+        :type f_max: float, optional
+        :return: indices of top n modes sorted by amplitude or integral
+            contribution
+        :rtype: pt.Tensor
+        """
+        modes_in_range = pt.logical_and(self.frequency >= f_min, self.frequency < f_max)
+        mode_indices = pt.tensor(range(modes_in_range.shape[0]), dtype=pt.int64)[
+            modes_in_range
+        ]
+        n = min(n, mode_indices.shape[0])
+        top_n = self.amplitude[mode_indices].abs().topk(n).indices
+        return mode_indices[top_n]
+
+
+class PDFT(DFT):
+    """Compute the DFT of the POD time coefficients."""
+
+    def __init__(
+        self,
+        data_matrix: pt.Tensor,
+        dt: float,
+        rank: int | None = None,
+        nfft: int | None = None,
+        device: str = "cpu",
+    ):
+        """Compute the DFT of the POD time coefficients.
+
+        First, the POD basis is computed by means of an SVD. The POD basis may
+        be truncated to reduce noise in the spectrum. Only the time coefficients
+        are Fourier-transformed. Without rank truncation, this yields the DFT
+        of the data matrix (the DFT modes need to be projected back onto the POD basis).
+        For large data matrices, the projection step reduces the computational
+        cost and storage requirements significantly.
+
+        :param data_matrix: M x N data matrix, where M is the number of spatial points
+            and N is the number of time instances
+        :type data_matrix: pt.Tensor
+        :param dt: timestep between snapshots; must be constant
+        :type dt: float
+        :param rank: truncation parameter for the POD basis, defaults to None
+            (automatic selection in the SVD class)
+        :type rank: int | None, optional
+        :param nfft: number of FFT frequency bin; zero-padding or truncation is
+            used if nfft > N or nfft < N, respectively, defaults to N
+        :type nfft: int | None, optional
+        :param device: device on which to perform the DFT, defaults to "cpu"
+        :type device: str, optional
+        """
+        self._dm_org = data_matrix
+        self._svd = SVD(self._dm_org, rank)
+        super(PDFT, self).__init__(
+            (self._svd.V * self._svd.s).T,
+            dt,
+            nfft,
+            device,
+        )
+
+    @property
+    def svd(self) -> SVD:
+        """SVD used to obtain the POD basis.
+
+        :return: SVD of the original data matrix
+        :rtype: SVD
+        """
+        return self._svd
+
+    @property
+    def amplitude(self) -> pt.Tensor:
+        """Rescaled amplitudes consistent with DFT.
+
+        :return: amplitudes considering the size of the full state
+        :rtype: pt.Tensor
+        """
+        return super().amplitude * sqrt(self._dm.shape[0]) / sqrt(self._dm_org.shape[0])
+
+    @property
+    def modes(self) -> pt.Tensor:
+        """DFT modes in the original space.
+
+        :return: DFT modes projected onto the POD basis
+        :rtype: pt.Tensor
+        """
+        m = super().modes
+        return self._svd.U.type(m.dtype) @ m
+
+    def partial_reconstruction(
+        self, mode_indices: Set[int] | int, include_mean: bool = False
+    ) -> pt.Tensor:
+        """Partial reconstruction projected onto the POD basis."""
+        return self._svd.U @ super().partial_reconstruction(mode_indices, include_mean)

--- a/flowtorch/analysis/test_dft.py
+++ b/flowtorch/analysis/test_dft.py
@@ -1,0 +1,101 @@
+"""Unittests for computing the DFT."""
+
+from pytest import raises
+import torch as pt
+from .dft import DFT, PDFT
+
+
+def test_DFT():
+    dm_complex_even = pt.tensor(
+        [
+            [0.0 + 1.0j, 2.0 + 3.0j, 4.0 + 5.0j, 6.0 + 7.0j],
+            [0.1 + 1.0j, 2.0 + 3.0j, 4.0 + 5.0j, 6.0 + 7.0j],
+        ]
+    )
+    dm_complex_odd = pt.tensor(
+        [
+            [0.0 + 1.0j, 2.0 + 3.0j, 4.0 + 5.0j],
+            [0.1 + 1.0j, 2.0 + 3.0j, 4.0 + 5.0j],
+        ]
+    )
+    dm_real_even = pt.tensor(
+        [
+            [0.0, 1.0, 2.0, 3.0, 4.0, 5.0],
+            [0.1, 1.0, 2.0, 3.0, 4.0, 5.0],
+        ]
+    )
+    dm_real_odd = pt.tensor(
+        [
+            [0.0, 1.0, 2.0, 3.0, 4.0],
+            [0.1, 1.0, 2.0, 3.0, 4.0],
+        ]
+    )
+    # complex inputs, default arguments
+    dft = DFT(dm_complex_even, 1.0)
+    nfreq = dm_complex_even.shape[1] - 1
+    assert dft.amplitude.shape == (nfreq,)
+    assert dft.frequency.shape == (nfreq,)
+    assert pt.is_complex(dft.modes)
+    assert dft.modes.shape == (2, nfreq)
+    pt.testing.assert_close(dft.modes.norm(dim=0), pt.ones(nfreq))
+    pt.testing.assert_close(dft.reconstruction, dm_complex_even)
+    # complex inputs, GPU
+    if pt.cuda.is_available():
+        dft = DFT(dm_complex_odd, 1.0, device="cuda")
+        nfreq = dm_complex_odd.shape[1] - 1
+        assert dft.amplitude.shape == (nfreq,)
+        assert dft.frequency.shape == (nfreq,)
+        assert pt.is_complex(dft.modes)
+        assert dft.modes.shape == (2, nfreq)
+        pt.testing.assert_close(dft.modes.norm(dim=0), pt.ones(nfreq))
+        pt.testing.assert_close(dft.reconstruction, dm_complex_odd)
+    # real inputs, default arguments
+    dft = DFT(dm_real_even, 1.0)
+    nfreq = dm_real_even.shape[1] // 2
+    assert dft.amplitude.shape == (nfreq,)
+    assert dft.frequency.shape == (nfreq,)
+    assert pt.is_complex(dft.modes)
+    assert dft.modes.shape == (2, nfreq)
+    pt.testing.assert_close(dft.modes.norm(dim=0), pt.ones(nfreq))
+    pt.testing.assert_close(dft.reconstruction, dm_real_even)
+    part = dft.partial_reconstruction(0)
+    assert part.shape == dm_real_even.shape
+    assert part.dtype == dm_real_even.dtype
+    part = dft.partial_reconstruction({0, 2})
+    assert part.shape == dm_real_even.shape
+    assert part.dtype == dm_real_even.dtype
+    assert len(dft.top_modes(2)) == 2
+    with raises(Exception):
+        _ = dft.partial_reconstruction(99)
+    # real inputs, GPU
+    if pt.cuda.is_available():
+        nfft = 12
+        dft = DFT(dm_real_odd, 1.0, nfft=nfft, device="cuda")
+        nfreq = nfft // 2
+        assert dft.amplitude.shape == (nfreq,)
+        assert dft.frequency.shape == (nfreq,)
+        assert pt.is_complex(dft.modes)
+        assert dft.modes.shape == (2, nfreq)
+        pt.testing.assert_close(dft.modes.norm(dim=0), pt.ones(nfreq))
+        rec = dft.reconstruction
+        assert not pt.is_complex(rec)
+        assert rec.shape == (2, nfft)
+
+
+def test_PDFT():
+    M, N = 100, 40
+    dm = pt.rand((M, N))
+    dft = PDFT(dm, 1.0, N)
+    modes = dft.modes
+    assert modes.shape == (M, N // 2)
+    assert pt.is_complex(modes)
+    rec = dft.reconstruction
+    pt.testing.assert_close(rec, dm)
+    assert len(dft.top_modes()) == 1
+    # rank truncation
+    dft = PDFT(dm, 1.0, 20)
+    assert dft.svd.rank == 20
+    modes = dft.modes
+    assert modes.shape == (M, N // 2)
+    rec = dft.reconstruction
+    pt.testing.assert_close(rec, dft.svd.reconstruct(20))

--- a/flowtorch/analysis/test_dft.py
+++ b/flowtorch/analysis/test_dft.py
@@ -64,7 +64,7 @@ def test_DFT():
     part = dft.partial_reconstruction({0, 2})
     assert part.shape == dm_real_even.shape
     assert part.dtype == dm_real_even.dtype
-    assert len(dft.top_modes(2)) == 2
+    assert len(dft.top_modes(2, False)) == 2
     with raises(Exception):
         _ = dft.partial_reconstruction(99)
     # real inputs, GPU

--- a/flowtorch/data/tau_dataloader.py
+++ b/flowtorch/data/tau_dataloader.py
@@ -229,15 +229,6 @@ class TAUBase(Dataloader):
         """
         pass
 
-    @abstractmethod
-    def _load_mesh_weights(self, n_points: int):
-        """Load cell volumes from last snapshot
-
-        :param n_points: number of points in the mesh
-        :type n_points: int
-        """
-        pass
-
     def load_snapshot(self, field_name: Union[List[str], str],
                       time: Union[List[str], str]) -> Union[List[pt.Tensor], pt.Tensor]:
         check_list_or_str(field_name, "field_name")
@@ -330,17 +321,16 @@ class TAUDataloader(TAUBase):
         path = join(self._para.path, name)
         with Dataset(path) as data:
             vertices = pt.tensor(data[PVERTEX_KEY][:], dtype=self._dtype)
-            volumes = pt.tensor(data[PWEIGHT_KEY][:], dtype=self._dtype)
             global_ids = pt.tensor(data[PGLOBAL_ID_KEY][:], dtype=pt.int64)
             n_add_points = data[PADD_POINTS_KEY].shape[0]
 
-        n_points = volumes.shape[0] - n_add_points
+        n_points = vertices.shape[0] - n_add_points
         data = pt.zeros((n_points, 4), dtype=self._dtype)
         sorting = pt.argsort(global_ids[:n_points])
         data[:, 0] = vertices[:n_points, 0][sorting]
         data[:, 1] = vertices[:n_points, 1][sorting]
         data[:, 2] = vertices[:n_points, 2][sorting]
-        data[:, 3] = volumes[:n_points][sorting]
+        data[:, 3] = pt.ones(n_points, self._dtype)
         return data
 
     def _load_mesh_data(self):
@@ -364,28 +354,12 @@ class TAUDataloader(TAUBase):
                      for key in VERTEX_KEYS],
                     dim=-1
                 )
-            weights = self._load_mesh_weights(vertices.shape[0])
+            weights = pt.ones(vertices.shape[0], self._dtype)
             self._mesh_data = pt.cat((vertices, weights.unsqueeze(-1)), dim=-1)
-    
-    def _load_mesh_weights(self, n_points: int) -> pt.Tensor:
-        """Load mesh cell volumes.
-
-        Load the cell volumes as tensor of dimension n_points from the last 
-        snapshot and return a tensor of ones if that fails.
-        """
-        if self._distributed:
-            raise NotImplementedError
-        else:
-            path = join(self._para.path, self._file_name(self.write_times[-1]))
-            with Dataset(path) as data:
-                if WEIGHT_KEY in data.variables.keys():
-                    weights = pt.tensor(
-                        data.variables[WEIGHT_KEY][:], dtype=self._dtype)
-                else:
-                    logger.warning(f"Could not find cell volumes in file {path}")
-                    weights = pt.ones(n_points, dtype=self._dtype)
-            return weights
-
+        try:
+            self._mesh_data[:,3] = self._load_single_snapshot(WEIGHT_KEY, self.write_times[-1])
+        except KeyError:
+            logger.warning(f"Could not find cell volumes in last snapshot.")
 
     def _load_single_snapshot(self, field_name: str, time: str) -> pt.Tensor:
         """Load a single snapshot of a single field from the netCDF4 file(s).
@@ -554,30 +528,17 @@ class TAUSurfaceDataloader(TAUBase):
                  for key in VERTEX_KEYS],
                 dim=-1
             )
-        weights = self._load_mesh_weights(vertices.shape[0])
+        try:
+            weights = self._load_single_snapshot(WEIGHT_KEY, self.write_times[-1])
+        except KeyError:
+            logger.warning(f"Could not find cell volumes in last snapshot.")
+            weights = pt.ones(vertices.shape[0])
         self._mesh_data = {}
         for zone_name, zone_ids in self.zone_ids.items():
             self._mesh_data[zone_name] = pt.ones(
                 (zone_ids.size(0), 4), dtype=self._dtype)
             self._mesh_data[zone_name][:, :3] = vertices[zone_ids]
-            self._mesh_data[zone_name][:,3] = weights[zone_ids]
-    
-    def _load_mesh_weights(self, n_points: int) -> pt.Tensor:
-        """Load mesh cell volumes of the first layer cells.
-
-        Load the cell volumes as tensor of dimension n_points from the last 
-        snapshot and return a tensor of ones if that fails.
-        """
-        path = join(self._para.path, self._file_name(self.write_times[-1]))
-        with Dataset(path) as data:
-            if WEIGHT_KEY in data.variables.keys():
-                weights = pt.tensor(
-                    data.variables[WEIGHT_KEY][:], dtype=self._dtype)
-            else:
-                logger.warning(f"Could not find cell volumes in file {path}")
-                weights = pt.ones(n_points, dtype=self._dtype)
-        return weights
-
+            self._mesh_data[zone_name][:,  3] = weights[zone_ids]
 
     def _load_single_snapshot(self, field_name: str, time: str) -> pt.Tensor:
         with Dataset(self._file_name(time)) as data:

--- a/flowtorch/data/tau_dataloader.py
+++ b/flowtorch/data/tau_dataloader.py
@@ -29,11 +29,9 @@ logging.basicConfig(level=logging.INFO)
 VOL_SOLUTION_NAME = ".pval.unsteady_"
 SURF_SOLUTION_NAME = ".surface.pval.unsteady_"
 PSOLUTION_POSTFIX = ".domain_"
-PMESH_NAME = "domain_{:s}_grid_1"
-PVERTEX_KEY = "pcoord"
-PWEIGHT_KEY = "pvolume"
-PADD_POINTS_KEY = "addpoint_idx"
-PGLOBAL_ID_KEY = "globalidx"
+PMESH_NAME = "domain_{:s}"
+PADD_POINTS_KEY = "addpoint_id"
+PGLOBAL_ID_KEY = "global_id"
 VERTEX_KEYS = ("points_xc", "points_yc", "points_zc")
 WEIGHT_KEY = "volume"
 
@@ -319,23 +317,22 @@ class TAUDataloader(TAUBase):
             coordinates of the vertices (x, y, z) and the cell volumes
         :rtype: pt.Tensor
         """
-        prefix = self._para.config[GRID_PREFIX_KEY]
+        prefix = self._para.config[GRID_FILE_KEY]
         name = PMESH_NAME.format(pid)
         if not (prefix == "(none)"):
             name = f"{prefix}_{name}"
         path = join(self._para.path, name)
         with Dataset(path) as data:
-            vertices = pt.tensor(data[PVERTEX_KEY][:], dtype=self._dtype)
-            global_ids = pt.tensor(data[PGLOBAL_ID_KEY][:], dtype=pt.int64)
+            vertices = pt.stack([pt.tensor(data[key][:], dtype=self._dtype) 
+                                 for key in VERTEX_KEYS], dim=-1)
             n_add_points = data[PADD_POINTS_KEY].shape[0]
 
         n_points = vertices.shape[0] - n_add_points
         data = pt.zeros((n_points, 4), dtype=self._dtype)
-        sorting = pt.argsort(global_ids[:n_points])
-        data[:, 0] = vertices[:n_points, 0][sorting]
-        data[:, 1] = vertices[:n_points, 1][sorting]
-        data[:, 2] = vertices[:n_points, 2][sorting]
-        data[:, 3] = pt.ones(n_points, self._dtype)
+        data[:, 0] = vertices[:n_points, 0]
+        data[:, 1] = vertices[:n_points, 1]
+        data[:, 2] = vertices[:n_points, 2]
+        data[:, 3] = pt.ones(n_points, dtype=self._dtype)
         return data
 
     def _load_mesh_data(self):
@@ -359,7 +356,7 @@ class TAUDataloader(TAUBase):
                      for key in VERTEX_KEYS],
                     dim=-1
                 )
-            weights = pt.ones(vertices.shape[0], self._dtype)
+            weights = pt.ones(vertices.shape[0], dtype=self._dtype)
             self._mesh_data = pt.cat((vertices, weights.unsqueeze(-1)), dim=-1)
         try:
             self._mesh_data[:,3] = self._load_single_snapshot(WEIGHT_KEY, self.write_times[-1])

--- a/flowtorch/data/tau_dataloader.py
+++ b/flowtorch/data/tau_dataloader.py
@@ -229,6 +229,10 @@ class TAUBase(Dataloader):
         """
         pass
 
+    @abstractmethod
+    def _load_mesh_weights(self, n_points):
+        pass
+
     def load_snapshot(self, field_name: Union[List[str], str],
                       time: Union[List[str], str]) -> Union[List[pt.Tensor], pt.Tensor]:
         check_list_or_str(field_name, "field_name")
@@ -355,13 +359,28 @@ class TAUDataloader(TAUBase):
                      for key in VERTEX_KEYS],
                     dim=-1
                 )
+            weights = self._load_mesh_weights(vertices.shape[0])
+            self._mesh_data = pt.cat((vertices, weights.unsqueeze(-1)), dim=-1)
+    
+    def _load_mesh_weights(self, n_points: int) -> pt.Tensor:
+        """Load mesh cell volumes.
+
+        Load the cell volumes as tensor of dimension n_points from the last 
+        snapshot and return a tensor of ones if that fails.
+        """
+        if self._distributed:
+            raise NotImplementedError
+        else:
+            path = join(self._para.path, self._file_name(self.write_times[-1]))
+            with Dataset(path) as data:
                 if WEIGHT_KEY in data.variables.keys():
                     weights = pt.tensor(
                         data.variables[WEIGHT_KEY][:], dtype=self._dtype)
                 else:
-                    logger.warning(f"Could not find cell volumes in file {path}")
-                    weights = pt.ones(vertices.shape[0], dtype=self._dtype)
-            self._mesh_data = pt.cat((vertices, weights.unsqueeze(-1)), dim=-1)
+                    logger.warning(f"Could not fine cell in volumes in file {path}")
+                    weights = pt.ones(n_points, dtype=self._dtype)
+            return weights
+
 
     def _load_single_snapshot(self, field_name: str, time: str) -> pt.Tensor:
         """Load a single snapshot of a single field from the netCDF4 file(s).
@@ -520,7 +539,8 @@ class TAUSurfaceDataloader(TAUBase):
         The mesh data is saved as class member `_mesh_data`. The tensor for each zone
         has the dimension n_points x 4; the first three columns correspond to the x/y/z
         coordinates. Loading or computing the face area is currently not implemented;
-        instead, the weight of each element is set to unity.
+        instead, the cell volumes of the first layer cells are loaded, and if they are
+        not present the weights are set to unity.
         """
         path = join(self._para.path, self._para.config[GRID_FILE_KEY])
         with Dataset(path) as data:
@@ -529,11 +549,30 @@ class TAUSurfaceDataloader(TAUBase):
                  for key in VERTEX_KEYS],
                 dim=-1
             )
-            self._mesh_data = {}
-            for zone_name, zone_ids in self.zone_ids.items():
-                self._mesh_data[zone_name] = pt.ones(
-                    (zone_ids.size(0), 4), dtype=self._dtype)
-                self._mesh_data[zone_name][:, :3] = vertices[zone_ids]
+        weights = self._load_mesh_weights(vertices.shape[0])
+        self._mesh_data = {}
+        for zone_name, zone_ids in self.zone_ids.items():
+            self._mesh_data[zone_name] = pt.ones(
+                (zone_ids.size(0), 4), dtype=self._dtype)
+            self._mesh_data[zone_name][:, :3] = vertices[zone_ids]
+            self._mesh_data[zone_name][:,3] = weights[zone_ids]
+    
+    def _load_mesh_weights(self, n_points: int) -> pt.Tensor:
+        """Load mesh cell volumes of the first layer cells.
+
+        Load the cell volumes as tensor of dimension n_points from the last 
+        snapshot and return a tensor of ones if that fails.
+        """
+        path = join(self._para.path, self._file_name(self.write_times[-1]))
+        with Dataset(path) as data:
+            if WEIGHT_KEY in data.variables.keys():
+                weights = pt.tensor(
+                    data.variables[WEIGHT_KEY][:], dtype=self._dtype)
+            else:
+                logger.warning(f"Could not fine cell in volumes in file {path}")
+                weights = pt.ones(n_points, dtype=self._dtype)
+        return weights
+
 
     def _load_single_snapshot(self, field_name: str, time: str) -> pt.Tensor:
         with Dataset(self._file_name(time)) as data:

--- a/flowtorch/data/tau_dataloader.py
+++ b/flowtorch/data/tau_dataloader.py
@@ -428,7 +428,7 @@ class TAUDataloader(TAUBase):
     def weights(self) -> pt.Tensor:
         if self._mesh_data is None:
             self._load_mesh_data()
-        return self._mesh_data[:, 3]
+        return self._mesh_data[:, 3] / self._mesh_data[:, 3].max()
 
 
 class TAUSurfaceDataloader(TAUBase):
@@ -531,10 +531,10 @@ class TAUSurfaceDataloader(TAUBase):
                 dim=-1
             )
         try:
-            weights = self._load_single_snapshot(WEIGHT_KEY, self.write_times[-1])
+            weights = self._load_single_snapshot(WEIGHT_KEY, self.write_times[-1], return_all_zones=True)
         except KeyError:
             logger.warning(f"Could not find cell volumes in last snapshot.")
-            weights = pt.ones(vertices.shape[0])
+            weights = pt.ones(vertices.shape[0], dtype=self._dtype)
         self._mesh_data = {}
         for zone_name, zone_ids in self.zone_ids.items():
             self._mesh_data[zone_name] = pt.ones(
@@ -542,13 +542,16 @@ class TAUSurfaceDataloader(TAUBase):
             self._mesh_data[zone_name][:, :3] = vertices[zone_ids]
             self._mesh_data[zone_name][:,  3] = weights[zone_ids]
 
-    def _load_single_snapshot(self, field_name: str, time: str) -> pt.Tensor:
+    def _load_single_snapshot(self, field_name: str, time: str, return_all_zones=False) -> pt.Tensor:
         with Dataset(self._file_name(time)) as data:
             global_ids = pt.from_numpy(data.variables["global_id"][:])
             ids = pt.where(pt.isin(global_ids, self.zone_ids[self.zone]))[0].numpy()
             field = pt.tensor(
                 data.variables[field_name][:], dtype=self._dtype)
-        return field[ids]
+        if return_all_zones:
+            return field
+        else:
+            return field[ids]
 
     @property
     def field_names(self) -> Dict[str, List[str]]:
@@ -585,7 +588,7 @@ class TAUSurfaceDataloader(TAUBase):
 
     @property
     def weights(self) -> pt.Tensor:
-        return self.mesh_data[self.zone][:, 3]
+        return self.mesh_data[self.zone][:, 3] / self.mesh_data[self.zone][:, 3].max()
 
     @property
     def zone_ids(self) -> Dict[str, pt.Tensor]:

--- a/flowtorch/data/tau_dataloader.py
+++ b/flowtorch/data/tau_dataloader.py
@@ -131,7 +131,12 @@ class TAUConfig(object):
                     else:
                         continue
                 if block_end_found and write_surface_data:
-                    bmap[name] = markers
+                    if name in bmap.keys():
+                        name_with_marker = f"{name}_marker{str(int(markers[0]))}"
+                        bmap[name_with_marker] = markers
+                        logger.warning(f"Duplicate zone name {name} replaced by {name_with_marker}.")
+                    else:
+                        bmap[name] = markers
         return bmap
 
     def _gather_config(self):

--- a/flowtorch/data/tau_dataloader.py
+++ b/flowtorch/data/tau_dataloader.py
@@ -230,7 +230,12 @@ class TAUBase(Dataloader):
         pass
 
     @abstractmethod
-    def _load_mesh_weights(self, n_points):
+    def _load_mesh_weights(self, n_points: int):
+        """Load cell volumes from last snapshot
+
+        :param n_points: number of points in the mesh
+        :type n_points: int
+        """
         pass
 
     def load_snapshot(self, field_name: Union[List[str], str],

--- a/flowtorch/data/tau_dataloader.py
+++ b/flowtorch/data/tau_dataloader.py
@@ -377,7 +377,7 @@ class TAUDataloader(TAUBase):
                     weights = pt.tensor(
                         data.variables[WEIGHT_KEY][:], dtype=self._dtype)
                 else:
-                    logger.warning(f"Could not fine cell in volumes in file {path}")
+                    logger.warning(f"Could not find cell volumes in file {path}")
                     weights = pt.ones(n_points, dtype=self._dtype)
             return weights
 
@@ -569,7 +569,7 @@ class TAUSurfaceDataloader(TAUBase):
                 weights = pt.tensor(
                     data.variables[WEIGHT_KEY][:], dtype=self._dtype)
             else:
-                logger.warning(f"Could not fine cell in volumes in file {path}")
+                logger.warning(f"Could not find cell volumes in file {path}")
                 weights = pt.ones(n_points, dtype=self._dtype)
         return weights
 

--- a/flowtorch/data/test_utils.py
+++ b/flowtorch/data/test_utils.py
@@ -1,8 +1,10 @@
 # third party packages
 import pytest
+from torch import rand, cat, zeros
 # flowtorch packages
 from flowtorch.data.utils import (format_byte_size, check_and_standardize_path,
                                   check_list_or_str)
+from flowtorch.data.utils import CellVolumeEstimator
 
 
 def test_byte_formatting():
@@ -30,3 +32,32 @@ def test_check_list_or_str():
         check_list_or_str(0, "test")
     with pytest.raises(ValueError):
         check_list_or_str(["", 0], "test")
+
+
+@pytest.mark.parametrize("dims, n_points", [(2, 100), (3, 200)])
+def test_cell_volume_estimator(dims: int, n_points: int):
+    # make up some coordinates
+    coords = rand(n_points, dims)
+
+    # add a flat dimension to simulate 2D simulation when passing 3D points
+    if dims == 2:
+        coords = cat([coords, zeros(n_points, 1)], dim=1)
+
+    estimator = CellVolumeEstimator(coords, k=4, lr=1e-2, max_iterations=500)
+
+    # ensure dimensionality detection works
+    if dims == 2:
+        assert len(estimator._dims) == 2
+    else:
+        assert len(estimator._dims) == 3
+
+    # execute estimation
+    estimator.estimate_cell_volume()
+
+    # check weights shape matches number of points
+    assert estimator.weights.shape[0] == n_points
+
+    # volumes should be positive
+    assert estimator._volume_original > 0
+    assert all(estimator.weights > 0)
+

--- a/flowtorch/data/test_utils.py
+++ b/flowtorch/data/test_utils.py
@@ -51,9 +51,6 @@ def test_cell_weight_estimator(dims: int, n_points: int):
     else:
         assert len(estimator._dims) == 3
 
-    # execute estimation
-    estimator.estimate_cell_weights()
-
     # check weights shape matches number of points
     assert estimator.weights.shape[0] == n_points
 
@@ -62,5 +59,4 @@ def test_cell_weight_estimator(dims: int, n_points: int):
 
     # since we normalize the weights they should be in [0, 1]
     assert all(estimator.weights >= 0)
-    assert all(estimator.weights <= 1)
 

--- a/flowtorch/data/test_utils.py
+++ b/flowtorch/data/test_utils.py
@@ -43,7 +43,7 @@ def test_cell_volume_estimator(dims: int, n_points: int):
     if dims == 2:
         coords = cat([coords, zeros(n_points, 1)], dim=1)
 
-    estimator = CellVolumeEstimator(coords, k=4, lr=1e-2, max_iterations=500)
+    estimator = CellVolumeEstimator(coords, k=4, normalize=True)
 
     # ensure dimensionality detection works
     if dims == 2:
@@ -59,5 +59,8 @@ def test_cell_volume_estimator(dims: int, n_points: int):
 
     # volumes should be positive
     assert estimator._volume_original > 0
-    assert all(estimator.weights > 0)
+
+    # since we normalize the weights they should be in [0, 1]
+    assert all(estimator.weights >= 0)
+    assert all(estimator.weights <= 1)
 

--- a/flowtorch/data/test_utils.py
+++ b/flowtorch/data/test_utils.py
@@ -59,4 +59,5 @@ def test_cell_weight_estimator(dims: int, n_points: int):
 
     # since we normalize the weights they should be in [0, 1]
     assert all(estimator.weights >= 0)
+    assert all(estimator.weights <= 1)
 

--- a/flowtorch/data/test_utils.py
+++ b/flowtorch/data/test_utils.py
@@ -4,7 +4,7 @@ from torch import rand, cat, zeros
 # flowtorch packages
 from flowtorch.data.utils import (format_byte_size, check_and_standardize_path,
                                   check_list_or_str)
-from flowtorch.data.utils import CellVolumeEstimator
+from flowtorch.data.utils import CellWeightEstimator
 
 
 def test_byte_formatting():
@@ -35,7 +35,7 @@ def test_check_list_or_str():
 
 
 @pytest.mark.parametrize("dims, n_points", [(2, 100), (3, 200)])
-def test_cell_volume_estimator(dims: int, n_points: int):
+def test_cell_weight_estimator(dims: int, n_points: int):
     # make up some coordinates
     coords = rand(n_points, dims)
 
@@ -43,7 +43,7 @@ def test_cell_volume_estimator(dims: int, n_points: int):
     if dims == 2:
         coords = cat([coords, zeros(n_points, 1)], dim=1)
 
-    estimator = CellVolumeEstimator(coords, k=4, normalize=True)
+    estimator = CellWeightEstimator(coords, normalize=True)
 
     # ensure dimensionality detection works
     if dims == 2:
@@ -52,7 +52,7 @@ def test_cell_volume_estimator(dims: int, n_points: int):
         assert len(estimator._dims) == 3
 
     # execute estimation
-    estimator.estimate_cell_volume()
+    estimator.estimate_cell_weights()
 
     # check weights shape matches number of points
     assert estimator.weights.shape[0] == n_points

--- a/flowtorch/data/utils.py
+++ b/flowtorch/data/utils.py
@@ -79,10 +79,6 @@ def check_list_or_str(arg_value: Union[List[str], str], arg_name: str):
 class CellVolumeEstimator:
     """
     Estimate cell volumes based on a point cloud of coordinates.
-    TODO: don't use optimization, just multiply with inverse on volume ratio to get alpha.
-          Normalize weights to [0, 1] to avoid issue with different orders
-          issue if domain is nor rectangluar and not alinged with coord. axis
-            -> overall computation of cell volume not working, maybe compute convex hull instead
 
     The algorithm works in three main steps:
         1. Build a KD-tree to compute the mean distances between each point and its

--- a/flowtorch/data/utils.py
+++ b/flowtorch/data/utils.py
@@ -139,7 +139,7 @@ class CellWeightEstimator:
         self.weights = None
         self._dist = None
         self.alpha = 1
-        self.min_max_sqrt = ()
+        self.max_sqrt = 1
 
         # compute the mean distance for each point
         self._duration = 0
@@ -154,7 +154,7 @@ class CellWeightEstimator:
         Runs the full pipeline:
             - Optimizes scaling factor :math:`\\alpha`.
             - Scales the weights accordingly.
-            - Normalizes the sqrt of the weights if specified.
+            - Normalizes the sqrt of the max. weights if specified.
             - Prints information summary to the logger.
         """
         _time_start = time()
@@ -200,12 +200,12 @@ class CellWeightEstimator:
 
     def _normalize_weights(self) -> None:
         """
-        Normalizes the weights to [0, 1] using min-max. normalization
+        Normalizes the weights with the sqrt(max).
 
         :return: None
         """
-        self.min_max_sqrt = (self._dist.sqrt().min(), self._dist.sqrt().max())
-        self.weights = (self._dist.sqrt() - self.min_max_sqrt[0]) / (self.min_max_sqrt[1] - self.min_max_sqrt[0])
+        self.max_sqrt = self._dist.sqrt().max()
+        self.weights = self._dist.sqrt() / self.max_sqrt
 
     def _print_info(self) -> None:
         """

--- a/flowtorch/data/utils.py
+++ b/flowtorch/data/utils.py
@@ -195,8 +195,8 @@ class CellWeightEstimator:
 
         :return: None
         """
-        self.alpha = self._volume_original / self.weights.sum()
-        self.weights *= self.alpha
+        self.alpha = self._volume_original / self._dist.sum()
+        self.weights = self.alpha * self._dist
 
     def _normalize_weights(self) -> None:
         """
@@ -229,7 +229,7 @@ class CellWeightEstimator:
                 \t\t -> approximation of {self._sum_weights * self.alpha / self._volume_original * 100:.3f} %.
                 Computed cell volumes (min. / max.):\t{self.weights.min().item():.3e}, {self.weights.max().item():.3e}
 
-                Approximation took {time() - self._time_start:.3f} s.
+                Approximation took {self._duration:.3f} s.
         """
         logger.info(msg)
 

--- a/flowtorch/data/utils.py
+++ b/flowtorch/data/utils.py
@@ -6,7 +6,6 @@ from os.path import exists
 from os import sep
 from typing import Tuple, List, Union
 
-from time import time
 from scipy.spatial import KDTree, ConvexHull
 from torch import Tensor, float32, from_numpy, where
 
@@ -97,10 +96,13 @@ class CellWeightEstimator:
         >>> # Generate a synthetic point cloud inside a unit square
         >>> coords = torch.rand(100, 2)
         >>> estimator = CellWeightEstimator(coords, n_workers=4, normalize=True)
-        >>> estimator.estimate_cell_weights()
         >>>
         >>> # Access estimated volumes per point
         >>> print(estimator.weights.shape)
+        >>> # Access unscaled weights
+        >>> estimator.normalize = False
+        >>> print(estimator.weights.shape)
+
 
     :param coordinates: Input tensor of coordinates with shape
         ``(n_points, n_dims)``.
@@ -134,37 +136,11 @@ class CellWeightEstimator:
         self._n_dims = self._vertices.size(1)
         self._sum_weights = None
         self._time_start = 0
-
-        # public
-        self.weights = None
-        self._dist = None
-        self.alpha = 1
-        self.max_sqrt = 1
+        self._max_sqrt = 1
 
         # compute the mean distance for each point
-        self._duration = 0
-        _time_start = time()
         self._compute_mean_distance()
-        self._duration_fit = time() - _time_start
-
-    def estimate_cell_weights(self) -> None:
-        """
-        Main entry point for estimating cell volumes.
-
-        Runs the full pipeline:
-            - Optimizes scaling factor :math:`\\alpha`.
-            - Scales the weights accordingly.
-            - Normalizes the sqrt of the max. weights if specified.
-            - Prints information summary to the logger.
-        """
-        _time_start = time()
-        self._compute_alpha()
-        if self._normalize:
-            self._normalize_weights()
-        else:
-            self.weights = self._dist
-        self._duration = self._duration_fit + (time() - _time_start)
-        self._print_info()
+        self._alpha = self._volume_original / self._dist.sum()
 
     def _compute_mean_distance(self) -> None:
         """
@@ -185,18 +161,9 @@ class CellWeightEstimator:
 
         # mean distance to nearest neighbor
         self._dist = from_numpy(dists.mean(axis=1)) ** self._n_dims
-        self._sum_weights = self.weights.sum().type(float32)
+        self._sum_weights = self._dist.sum().type(float32)
+        self._max_sqrt = self._dist.sqrt().max()
         logger.info("Done.")
-
-    def _compute_alpha(self) -> None:
-        """
-        Computes the scaling factor :math:`\\alpha` such that the total sum of
-        estimated volumes matches the original bounding-box volume.
-
-        :return: None
-        """
-        self.alpha = self._volume_original / self._dist.sum()
-        self.weights = self.alpha * self._dist
 
     def _normalize_weights(self) -> None:
         """
@@ -204,34 +171,61 @@ class CellWeightEstimator:
 
         :return: None
         """
-        self.max_sqrt = self._dist.sqrt().max()
-        self.weights = self._dist.sqrt() / self.max_sqrt
+        return self._alpha * self._dist.sqrt() / self._max_sqrt
 
-    def _print_info(self) -> None:
+    @property
+    def alpha(self) -> float:
         """
-        Print a summary of the volume estimation before and after optimization.
-
-        The summary includes:
-            - Bounding box volume
-            - Approximated volume before optimization
-            - Approximated volume after optimization
-            - Min/max local cell volumes
-            - Total runtime
+        Computes the scaling factor :math:`\\alpha` such that the total sum of
+        estimated volumes matches the original bounding-box volume.
 
         :return: None
         """
-        msg = f"""
+        return self._alpha
 
-                Overall cell volume estimated from coordinates:\t{self._volume_original:.5f}
-                Overall cell volume estimated before optimization:\t{self._sum_weights.item():.5f}
-                \t\t -> approximation of {self._sum_weights / self._volume_original * 100:.3f} %.
-                Overall cell volume estimated after optimization:\t{self.alpha * self._sum_weights.item():.5f}
-                \t\t -> approximation of {self._sum_weights * self.alpha / self._volume_original * 100:.3f} %.
-                Computed cell volumes (min. / max.):\t{self.weights.min().item():.3e}, {self.weights.max().item():.3e}
-
-                Approximation took {self._duration:.3f} s.
+    @property
+    def weights(self) -> Tensor:
         """
-        logger.info(msg)
+        Returns the estimated cell volumes. If ``normalize = True`` the normalized square-root of the volumes with its
+        maximum cell volume.
+
+        :return: Estimated cell volume, either the absolute value or scaled with the maximum value.
+        :rtype: Tensor
+        """
+        if self._normalize:
+            return self._normalize_weights()
+        else:
+            return self.alpha * self._dist
+
+    @property
+    def normalize(self) -> bool:
+        """
+        Get the current status for normalization
+
+        :return: Flag if normalization is turned on or off
+        :rtype: bool
+        """
+        return self._normalize
+
+    @normalize.setter
+    def normalize(self, value: bool) -> None:
+        """
+        Set a new value for normalizing the cell volumes.
+
+        :param value: bool
+        :return: None
+        """
+        self._normalize = value
+
+    @property
+    def max_sqrt(self) -> Tensor:
+        """
+        Get the max. value of the sqrt() of the estimated cell volumes.
+
+        :return: max(sqrt(cell volumes))
+        :rtype: Tensor
+        """
+        return self._max_sqrt
 
 
 if __name__ == "__main__":

--- a/flowtorch/data/utils.py
+++ b/flowtorch/data/utils.py
@@ -7,10 +7,8 @@ from os import sep
 from typing import Tuple, List, Union
 
 from time import time
-from torch.nn import Parameter
-from scipy.spatial import KDTree
-from torch.optim import Adam, lr_scheduler
-from torch import Tensor, tensor, float32, from_numpy, where, manual_seed
+from scipy.spatial import KDTree, ConvexHull
+from torch import Tensor, float32, from_numpy, where
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO, format='[%(asctime)s] %(levelname)-8s %(message)s', datefmt='%Y-%m-%d %H:%M:%S',
@@ -81,14 +79,19 @@ def check_list_or_str(arg_value: Union[List[str], str], arg_name: str):
 class CellVolumeEstimator:
     """
     Estimate cell volumes based on a point cloud of coordinates.
+    TODO: don't use optimization, just multiply with inverse on volume ratio to get alpha.
+          Normalize weights to [0, 1] to avoid issue with different orders
+          issue if domain is nor rectangluar and not alinged with coord. axis
+            -> overall computation of cell volume not working, maybe compute convex hull instead
 
     The algorithm works in three main steps:
         1. Build a KD-tree to compute the mean distances between each point and its
            :math:`k` nearest neighbors.
         2. Approximate local volumes as the mean neighbor distance raised to the
            power of the dimension (:math:`d`).
-        3. Optimize a scaling factor :math:`\\alpha` such that the sum of all
+        3. Calculate a scaling factor :math:`\\alpha` such that the sum of all
            estimated volumes matches the true bounding-box volume.
+        4. Normalization of weights to [0, 1] using min-max- scaling and :math:\\sqrt(weights) (optional)
 
     Example
     -------
@@ -102,8 +105,6 @@ class CellVolumeEstimator:
         >>>
         >>> # Access estimated volumes per point
         >>> print(estimator.weights.shape)
-        >>> # Access the optimization loss history
-        >>> print(estimator.loss[-5:])
 
     :param coordinates: Input tensor of coordinates with shape
         ``(n_points, n_dims)``.
@@ -111,37 +112,27 @@ class CellVolumeEstimator:
     :param k: Number of nearest neighbors to use for distance estimation
         (default: 8 for 3D, 4 for 2D).
     :type k: int
-    :param lr: Learning rate for optimizing :math:`\\alpha`.
-    :type lr: float
-    :param max_iterations: Maximum number of optimization iterations.
-    :type max_iterations: int
-    :param stop_at: Stopping criterion for relative error in optimization.
-    :type stop_at: float
     :param n_workers: Number of parallel workers for KD-tree queries.
     :type n_workers: int
+    :param normalize: Normalize the computed volumes to [0, 1].
+    :type normalize: bool
     """
 
-    def __init__(self, coordinates: Tensor, k: int = 8, lr: float = 1e-2, max_iterations: int = 2500,
-                 stop_at: float = 1e-8, n_workers: int = 4, seed: int = 0):
+    def __init__(self, coordinates: Tensor, k: int = 8, n_workers: int = 4, normalize: bool = True):
+        self._normalize = normalize
         self._vertices = coordinates
         self._n_workers = n_workers
-
-        # ensure reproducibility
-        manual_seed(seed)
 
         # get the dimensions which are not zero, since e.g. in OpenFOAM we have 3D coordinates even for 2D simulations
         _tmp = (self._vertices == self._vertices[0]).all(dim=0)
         self._dims = where(_tmp == False)[0]
-        self._volume_original = (coordinates.max(dim=0).values -
-                                 coordinates.min(dim=0).values)[self._dims].prod().type(float32)
 
-        # optimization
+        # compute the overall volume of the domain
+        self._hull = ConvexHull(self._vertices[:, self._dims])
+        self._volume_original = self._hull.volume
+
+        # distances
         self._k = k if len(self._dims) == 3 else 4
-        self._max_steps = max_iterations if max_iterations > 0 else 1
-        self._stop = stop_at
-        self._alpha = Parameter(tensor(2, dtype=float32))
-        self._optimizer = Adam([self._alpha], lr=lr, weight_decay=1e-3)
-        self._scheduler = lr_scheduler.ReduceLROnPlateau(optimizer=self._optimizer, min_lr=1e-4, patience=10)
 
         # initialization
         self._n_dims = self._vertices.size(1)
@@ -150,7 +141,8 @@ class CellVolumeEstimator:
 
         # public
         self.weights = None
-        self.loss = []
+        self.alpha = 1
+        self.min_max_sqrt = ()
 
     def estimate_cell_volume(self) -> None:
         """
@@ -160,12 +152,14 @@ class CellVolumeEstimator:
             - Computes mean distances to neighbors.
             - Optimizes scaling factor :math:`\\alpha`.
             - Scales the weights accordingly.
+            - Normalizes the weights if specified.
             - Prints information summary to the logger.
         """
         self._time_start = time()
         self._compute_mean_distance()
-        self._optimize_alpha()
-        self.weights *= self._alpha.detach()
+        self._compute_alpha()
+        if self._normalize:
+            self._normalize_weights()
         self._print_info()
 
     def _compute_mean_distance(self) -> None:
@@ -190,35 +184,24 @@ class CellVolumeEstimator:
         self._sum_weights = self.weights.sum().type(float32)
         logger.info("Done.")
 
-    def _optimize_alpha(self) -> None:
+    def _compute_alpha(self) -> None:
         """
-        Optimize the scaling factor :math:`\\alpha` such that the total sum of
+        Computes the scaling factor :math:`\\alpha` such that the total sum of
         estimated volumes matches the original bounding-box volume.
 
         :return: None
         """
-        logger.info("Optimizing cell volumes.")
-        converged = False
-        for step in range(self._max_steps):
-            self._optimizer.zero_grad()
-            loss = abs(self._alpha * self._sum_weights - self._volume_original) / self._volume_original
-            loss.backward()
-            self._optimizer.step()
-            self._scheduler.step(loss)
+        self.alpha = self._volume_original / self.weights.sum()
+        self.weights *= self.alpha
 
-            if step % 100 == 0:
-                logger.info(f"Epoch {step:04d}, alpha = {self._alpha.item():.3f}, loss = {loss.item():.4e}")
+    def _normalize_weights(self) -> None:
+        """
+        Normalizes the weights to [0, 1] using min-max. normalization
 
-            if loss.item() < self._stop:
-                logger.info(f"Found optimal alpha = {self._alpha.item():.3f} after {step + 1} iterations with an "
-                            f"error of {loss.item():.3e}")
-                converged = True
-                break
-            self.loss.append(loss.detach().item())
-
-        if not converged:
-            logger.warning(f"Optimization of alpha did not converge after {step + 1} iterations. "
-                           f"Current alpha = {self._alpha.item():.3f}")
+        :return: None
+        """
+        self.min_max_sqrt = (self.weights.sqrt().min(), self.weights.sqrt().max())
+        self.weights = (self.weights.sqrt() - self.min_max_sqrt[0]) / (self.min_max_sqrt[1] - self.min_max_sqrt[0])
 
     def _print_info(self) -> None:
         """
@@ -235,16 +218,17 @@ class CellVolumeEstimator:
         """
         msg = f"""
 
-                Overall cell volume estimated from coordinates:\t{self._volume_original.item():.5f}
+                Overall cell volume estimated from coordinates:\t{self._volume_original:.5f}
                 Overall cell volume estimated before optimization:\t{self._sum_weights.item():.5f}
-                \t\t -> approximation of {self._sum_weights / self._volume_original.item() * 100:.3f} %.
-                Overall cell volume estimated after optimization:\t{self._alpha * self._sum_weights.item():.5f}
-                \t\t -> approximation of {self._sum_weights * self._alpha / self._volume_original.item() * 100:.3f} %.
+                \t\t -> approximation of {self._sum_weights / self._volume_original * 100:.3f} %.
+                Overall cell volume estimated after optimization:\t{self.alpha * self._sum_weights.item():.5f}
+                \t\t -> approximation of {self._sum_weights * self.alpha / self._volume_original * 100:.3f} %.
                 Computed cell volumes (min. / max.):\t{self.weights.min().item():.3e}, {self.weights.max().item():.3e}
 
                 Approximation took {time() - self._time_start:.3f} s.
         """
         logger.info(msg)
+
 
 if __name__ == "__main__":
     pass

--- a/flowtorch/data/utils.py
+++ b/flowtorch/data/utils.py
@@ -76,7 +76,7 @@ def check_list_or_str(arg_value: Union[List[str], str], arg_name: str):
             raise ValueError(message)
 
 
-class CellVolumeEstimator:
+class CellWeightEstimator:
     """
     Estimate cell volumes based on a point cloud of coordinates.
 
@@ -92,12 +92,12 @@ class CellVolumeEstimator:
     Example
     -------
         >>> import torch
-        >>> from flowtorch.data.utils import CellVolumeEstimator
+        >>> from flowtorch.data.utils import CellWeightEstimator
         >>>
         >>> # Generate a synthetic point cloud inside a unit square
         >>> coords = torch.rand(100, 2)
-        >>> estimator = CellVolumeEstimator(coords, k=4, lr=1e-2, max_iterations=1000)
-        >>> estimator.estimate_cell_volume()
+        >>> estimator = CellWeightEstimator(coords, n_workers=4, normalize=True)
+        >>> estimator.estimate_cell_weights()
         >>>
         >>> # Access estimated volumes per point
         >>> print(estimator.weights.shape)
@@ -114,7 +114,7 @@ class CellVolumeEstimator:
     :type normalize: bool
     """
 
-    def __init__(self, coordinates: Tensor, k: int = 8, n_workers: int = 4, normalize: bool = True):
+    def __init__(self, coordinates: Tensor, n_workers: int = 4, normalize: bool = True, k: int = 8):
         self._normalize = normalize
         self._vertices = coordinates
         self._n_workers = n_workers
@@ -140,7 +140,7 @@ class CellVolumeEstimator:
         self.alpha = 1
         self.min_max_sqrt = ()
 
-    def estimate_cell_volume(self) -> None:
+    def estimate_cell_weights(self) -> None:
         """
         Main entry point for estimating cell volumes.
 

--- a/flowtorch/data/utils.py
+++ b/flowtorch/data/utils.py
@@ -137,25 +137,33 @@ class CellWeightEstimator:
 
         # public
         self.weights = None
+        self._dist = None
         self.alpha = 1
         self.min_max_sqrt = ()
+
+        # compute the mean distance for each point
+        self._duration = 0
+        _time_start = time()
+        self._compute_mean_distance()
+        self._duration_fit = time() - _time_start
 
     def estimate_cell_weights(self) -> None:
         """
         Main entry point for estimating cell volumes.
 
         Runs the full pipeline:
-            - Computes mean distances to neighbors.
             - Optimizes scaling factor :math:`\\alpha`.
             - Scales the weights accordingly.
-            - Normalizes the weights if specified.
+            - Normalizes the sqrt of the weights if specified.
             - Prints information summary to the logger.
         """
-        self._time_start = time()
-        self._compute_mean_distance()
+        _time_start = time()
         self._compute_alpha()
         if self._normalize:
             self._normalize_weights()
+        else:
+            self.weights = self._dist
+        self._duration = self._duration_fit + (time() - _time_start)
         self._print_info()
 
     def _compute_mean_distance(self) -> None:
@@ -168,7 +176,7 @@ class CellWeightEstimator:
         :return: None
         """
         logger.info("Computing mean distances between the coordinates.")
-        # TODO: large memory requirement -> how can we get this cheaper?
+        # TODO: - large memory requirement -> how can we get this cheaper?
         tree = KDTree(self._vertices)
         dists, _ = tree.query(self._vertices, k=self._k, workers=self._n_workers)
 
@@ -176,7 +184,7 @@ class CellWeightEstimator:
         self._vertices = None
 
         # mean distance to nearest neighbor
-        self.weights = from_numpy(dists.mean(axis=1)) ** self._n_dims
+        self._dist = from_numpy(dists.mean(axis=1)) ** self._n_dims
         self._sum_weights = self.weights.sum().type(float32)
         logger.info("Done.")
 
@@ -196,8 +204,8 @@ class CellWeightEstimator:
 
         :return: None
         """
-        self.min_max_sqrt = (self.weights.sqrt().min(), self.weights.sqrt().max())
-        self.weights = (self.weights.sqrt() - self.min_max_sqrt[0]) / (self.min_max_sqrt[1] - self.min_max_sqrt[0])
+        self.min_max_sqrt = (self._dist.sqrt().min(), self._dist.sqrt().max())
+        self.weights = (self._dist.sqrt() - self.min_max_sqrt[0]) / (self.min_max_sqrt[1] - self.min_max_sqrt[0])
 
     def _print_info(self) -> None:
         """

--- a/flowtorch/data/utils.py
+++ b/flowtorch/data/utils.py
@@ -151,6 +151,7 @@ class CellWeightEstimator:
         dimensionality to obtain an initial approximation of local cell volumes.
 
         :return: None
+        :rtype: None
         """
         logger.info("Computing mean distances between the coordinates.")
         # TODO: - large memory requirement -> how can we get this cheaper?
@@ -165,21 +166,23 @@ class CellWeightEstimator:
         self._sum_weights = self._dist.sum().type(float32)
         logger.info("Done.")
 
-    def _normalize_weights(self) -> None:
+    def _normalize_weights(self) -> Tensor:
         """
         Normalizes the weights with the sqrt(max).
 
         :return: None
+        :rtype; None
         """
         return (self._alpha * self._dist).sqrt() / self._max_sqrt
 
     @property
     def alpha(self) -> float:
         """
-        Computes the scaling factor :math:`\\alpha` such that the total sum of
-        estimated volumes matches the original bounding-box volume.
+        Returns the scaling factor :math:`\\alpha` such that the total sum of
+        estimated volumes matches the convex hull of the original volume.
 
         :return: None
+        :rtype: float
         """
         return self._alpha
 

--- a/flowtorch/data/utils.py
+++ b/flowtorch/data/utils.py
@@ -1,10 +1,20 @@
 """Collection of utilities related to data and dataloaders."""
 
 # standard library packages
+import logging
 from os.path import exists
 from os import sep
 from typing import Tuple, List, Union
 
+from time import time
+from torch.nn import Parameter
+from scipy.spatial import KDTree
+from torch.optim import Adam, lr_scheduler
+from torch import Tensor, tensor, float32, from_numpy, where, manual_seed
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO, format='[%(asctime)s] %(levelname)-8s %(message)s', datefmt='%Y-%m-%d %H:%M:%S',
+                    force=True)
 
 def format_byte_size(size: int) -> Tuple[float, str]:
     """Convert a number of bytes into human-readable format.
@@ -66,3 +76,175 @@ def check_list_or_str(arg_value: Union[List[str], str], arg_name: str):
     else:
         if not isinstance(arg_value, str):
             raise ValueError(message)
+
+
+class CellVolumeEstimator:
+    """
+    Estimate cell volumes based on a point cloud of coordinates.
+
+    The algorithm works in three main steps:
+        1. Build a KD-tree to compute the mean distances between each point and its
+           :math:`k` nearest neighbors.
+        2. Approximate local volumes as the mean neighbor distance raised to the
+           power of the dimension (:math:`d`).
+        3. Optimize a scaling factor :math:`\\alpha` such that the sum of all
+           estimated volumes matches the true bounding-box volume.
+
+    Example
+    -------
+        >>> import torch
+        >>> from flowtorch.data.utils import CellVolumeEstimator
+        >>>
+        >>> # Generate a synthetic point cloud inside a unit square
+        >>> coords = torch.rand(100, 2)
+        >>> estimator = CellVolumeEstimator(coords, k=4, lr=1e-2, max_iterations=1000)
+        >>> estimator.estimate_cell_volume()
+        >>>
+        >>> # Access estimated volumes per point
+        >>> print(estimator.weights.shape)
+        >>> # Access the optimization loss history
+        >>> print(estimator.loss[-5:])
+
+    :param coordinates: Input tensor of coordinates with shape
+        ``(n_points, n_dims)``.
+    :type coordinates: torch.Tensor
+    :param k: Number of nearest neighbors to use for distance estimation
+        (default: 8 for 3D, 4 for 2D).
+    :type k: int
+    :param lr: Learning rate for optimizing :math:`\\alpha`.
+    :type lr: float
+    :param max_iterations: Maximum number of optimization iterations.
+    :type max_iterations: int
+    :param stop_at: Stopping criterion for relative error in optimization.
+    :type stop_at: float
+    :param n_workers: Number of parallel workers for KD-tree queries.
+    :type n_workers: int
+    """
+
+    def __init__(self, coordinates: Tensor, k: int = 8, lr: float = 1e-2, max_iterations: int = 2500,
+                 stop_at: float = 1e-8, n_workers: int = 4, seed: int = 0):
+        self._vertices = coordinates
+        self._n_workers = n_workers
+
+        # ensure reproducibility
+        manual_seed(seed)
+
+        # get the dimensions which are not zero, since e.g. in OpenFOAM we have 3D coordinates even for 2D simulations
+        _tmp = (self._vertices == self._vertices[0]).all(dim=0)
+        self._dims = where(_tmp == False)[0]
+        self._volume_original = (coordinates.max(dim=0).values -
+                                 coordinates.min(dim=0).values)[self._dims].prod().type(float32)
+
+        # optimization
+        self._k = k if len(self._dims) == 3 else 4
+        self._max_steps = max_iterations if max_iterations > 0 else 1
+        self._stop = stop_at
+        self._alpha = Parameter(tensor(2, dtype=float32))
+        self._optimizer = Adam([self._alpha], lr=lr, weight_decay=1e-3)
+        self._scheduler = lr_scheduler.ReduceLROnPlateau(optimizer=self._optimizer, min_lr=1e-4, patience=10)
+
+        # initialization
+        self._n_dims = self._vertices.size(1)
+        self._sum_weights = None
+        self._time_start = 0
+
+        # public
+        self.weights = None
+        self.loss = []
+
+    def estimate_cell_volume(self) -> None:
+        """
+        Main entry point for estimating cell volumes.
+
+        Runs the full pipeline:
+            - Computes mean distances to neighbors.
+            - Optimizes scaling factor :math:`\\alpha`.
+            - Scales the weights accordingly.
+            - Prints information summary to the logger.
+        """
+        self._time_start = time()
+        self._compute_mean_distance()
+        self._optimize_alpha()
+        self.weights *= self._alpha.detach()
+        self._print_info()
+
+    def _compute_mean_distance(self) -> None:
+        """
+        Compute the mean distances between points using a KD-tree.
+
+        The mean neighbor distance is then raised to the power of the
+        dimensionality to obtain an initial approximation of local cell volumes.
+
+        :return: None
+        """
+        logger.info("Computing mean distances between the coordinates.")
+        # TODO: large memory requirement -> how can we get this cheaper?
+        tree = KDTree(self._vertices)
+        dists, _ = tree.query(self._vertices, k=self._k, workers=self._n_workers)
+
+        # free up some memory
+        self._vertices = None
+
+        # mean distance to nearest neighbor
+        self.weights = from_numpy(dists.mean(axis=1)) ** self._n_dims
+        self._sum_weights = self.weights.sum().type(float32)
+        logger.info("Done.")
+
+    def _optimize_alpha(self) -> None:
+        """
+        Optimize the scaling factor :math:`\\alpha` such that the total sum of
+        estimated volumes matches the original bounding-box volume.
+
+        :return: None
+        """
+        logger.info("Optimizing cell volumes.")
+        converged = False
+        for step in range(self._max_steps):
+            self._optimizer.zero_grad()
+            loss = abs(self._alpha * self._sum_weights - self._volume_original) / self._volume_original
+            loss.backward()
+            self._optimizer.step()
+            self._scheduler.step(loss)
+
+            if step % 100 == 0:
+                logger.info(f"Epoch {step:04d}, alpha = {self._alpha.item():.3f}, loss = {loss.item():.4e}")
+
+            if loss.item() < self._stop:
+                logger.info(f"Found optimal alpha = {self._alpha.item():.3f} after {step + 1} iterations with an "
+                            f"error of {loss.item():.3e}")
+                converged = True
+                break
+            self.loss.append(loss.detach().item())
+
+        if not converged:
+            logger.warning(f"Optimization of alpha did not converge after {step + 1} iterations. "
+                           f"Current alpha = {self._alpha.item():.3f}")
+
+    def _print_info(self) -> None:
+        """
+        Print a summary of the volume estimation before and after optimization.
+
+        The summary includes:
+            - Bounding box volume
+            - Approximated volume before optimization
+            - Approximated volume after optimization
+            - Min/max local cell volumes
+            - Total runtime
+
+        :return: None
+        """
+        msg = f"""
+
+                Overall cell volume estimated from coordinates:\t{self._volume_original.item():.5f}
+                Overall cell volume estimated before optimization:\t{self._sum_weights.item():.5f}
+                \t\t -> approximation of {self._sum_weights / self._volume_original.item() * 100:.3f} %.
+                Overall cell volume estimated after optimization:\t{self._alpha * self._sum_weights.item():.5f}
+                \t\t -> approximation of {self._sum_weights * self._alpha / self._volume_original.item() * 100:.3f} %.
+                Computed cell volumes (min. / max.):\t{self.weights.min().item():.3e}, {self.weights.max().item():.3e}
+
+                Approximation took {time() - self._time_start:.3f} s.
+        """
+        logger.info(msg)
+
+if __name__ == "__main__":
+    pass

--- a/flowtorch/data/utils.py
+++ b/flowtorch/data/utils.py
@@ -141,6 +141,7 @@ class CellWeightEstimator:
         # compute the mean distance for each point
         self._compute_mean_distance()
         self._alpha = self._volume_original / self._dist.sum()
+        self._max_sqrt = (self._alpha * self._dist).sqrt().max()
 
     def _compute_mean_distance(self) -> None:
         """
@@ -162,7 +163,6 @@ class CellWeightEstimator:
         # mean distance to nearest neighbor
         self._dist = from_numpy(dists.mean(axis=1)) ** self._n_dims
         self._sum_weights = self._dist.sum().type(float32)
-        self._max_sqrt = self._dist.sqrt().max()
         logger.info("Done.")
 
     def _normalize_weights(self) -> None:
@@ -171,7 +171,7 @@ class CellWeightEstimator:
 
         :return: None
         """
-        return self._alpha * self._dist.sqrt() / self._max_sqrt
+        return (self._alpha * self._dist).sqrt() / self._max_sqrt
 
     @property
     def alpha(self) -> float:


### PR DESCRIPTION
# Problem statement
The previous implementation to load the cell volumes as weights in the TauDataloader was not working, as it assumed that the volumes are stored as an additional dataset within the mesh file. In contrast, if specified by the user, the volumes can be written to the snapshots (either surface or volume snapshots). 

# Solution
The current implementation tries to load the volumes from the last available snapshot. If this fails, a tensor of ones is returned (as in the previous implementation). Therefore backward compatibility is kept.

# Changes
No changes to the interfaces of TauDataloader or TauSurfaceDataloader are made, I just introduced a sub method of **_load_mesh_data** called **_load_mesh_weights** to handle loading the volume data from the last snapshot.

# Limitations
There is no option to store the cell face areas in surface datasets in Tau. But, as a workaround we can store the cell volumes of the boundary cells in the surface dataset. If the mesh was build with a constant first layer height, one could compute the face areas by dividing the volumes by the first layer height. This is however left to be manually implemented by the users in their analysis scripts. 