### PR TITLE
Add out-of-core distributed SVD and PAMSPOD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,10 @@ jobs:
         run: python -m pip install tox
 
       - name: Run multi-process tests
-        run: tox -e py312 -- tests/analysis/test_distributed_statistics.py
+        run: >-
+          tox -e py312 --
+          tests/analysis/test_distributed_statistics.py
+          tests/analysis/test_distributed_svd.py
 
   type-check:
     name: Type check (optional)

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Currently, the following sub-packages are under active development. Note that so
 - data accessors return PyTorch tensors, which can be used directly within your favorite machine learning library, e.g., *PyTorch*, *scikit-learn*, or *TensorFlow*
 - most algorithms run on CPU as well as on GPU
 - snapshot statistics support batched, masked, and distributed processing across CPU nodes or GPUs
+- SVD and PAMSPOD support normalized multi-field state vectors, out-of-core batches, spatial distribution, and lazy physical-field reconstruction
 - mixed-precision operations (single/double); switching to single precision makes your life significantly easier when dealing with large datasets
 - user-friendly Python library that integrates easily with popular tools and libraries like *Jupyterlab*, *Matplotlib*, *Pandas*, or *Numpy*
 - a rich tutorial collection to help you get started
@@ -125,6 +126,8 @@ is needed.
 For an introduction to computing moments, fraction dependencies, trends,
 spatial summaries, and histograms from large snapshot sequences, see the
 [snapshot-statistics guide](https://flowtorch.readthedocs.io/en/latest/snapshot_statistics.html).
+For very tall state matrices, see the
+[out-of-core and distributed SVD/SPOD guide](https://flowtorch.readthedocs.io/en/latest/distributed_svd_spod.html).
 
 To get an overview of what *flowTorch* can do for you, have a look at the [online documentation](https://flowtorch.readthedocs.io/en/latest/). The examples presented in the online documentation are also contained in this repository. In fact, the documentation is a static version of several [Jupyter notebooks](https://jupyter.org/) with end-to-end analyses. If you are interested in an interactive version of one particular example, navigate to `./docs/source/notebooks` and run `jupyter lab`. Note that to execute some of the notebooks, the **corresponding datasets are required**. The datasets can be downloaded [here](https://datashare.tu-dresden.de/s/rekLnoqzRCp9zk9) (~2.6GB). If the data are only required for unit testing, a reduced dataset may be downloaded [here](https://datashare.tu-dresden.de/s/dr7gBPSdeyXQrgd) (~411MB). Download the data into a directory of your choice and navigate into that directory. To extract the archive, run:
 ```

--- a/docs/source/distributed_svd_spod.rst
+++ b/docs/source/distributed_svd_spod.rst
@@ -1,0 +1,221 @@
+Out-of-core and distributed SVD/SPOD
+====================================
+
+flowTorch can construct a flat physical state vector lazily and compute its
+SVD without materializing the complete data matrix.  The same public API covers
+in-memory tensors, shared-memory out-of-core execution, and spatially
+distributed execution.  PAMSPOD can either construct that SVD or reuse an
+existing one.
+
+State-vector layout and normalization
+-------------------------------------
+
+Every snapshot must have the same spatial shape.  Component dimensions follow
+the spatial dimensions in each field.  The state vector stores complete scalar
+components contiguously, in field order.  One normalization scalar is required
+per physical field, and that scalar is shared by all components of vector or
+tensor fields::
+
+    from flowtorch.analysis import (
+        DataloaderStateVectorSource,
+        FieldSpec,
+        PAMSPOD,
+        SVD,
+    )
+
+    fields = (
+        FieldSpec("U", component_shape=(3,), component_names=("u", "v", "w")),
+        FieldSpec("p"),
+    )
+    source = DataloaderStateVectorSource(
+        loader,
+        fields,
+        times=loader.write_times,
+        normalization={"U": 20.0, "p": 100_000.0},
+        spatial_weight=loader.weights,
+    )
+
+The factors above produce ``[U_x/20, U_y/20, U_z/20, p/100000]`` in the flat
+state.  Use ``normalization="rms"`` instead to fit one weighted fluctuation RMS
+per field during the first decomposition.  Fitted values are frozen and reused
+by :meth:`~flowtorch.analysis.state_vector.DataloaderStateVectorSource.with_times`,
+so appended data do not silently change the definition of the state vector.
+
+Shared-memory, out-of-core execution
+------------------------------------
+
+Omitting ``execution`` selects a single-process SVD.  PyTorch may still use its
+CPU thread pool or one GPU, while flowTorch limits data loading to spatial and
+snapshot batches::
+
+    svd = SVD(
+        source,
+        rank=40,
+        subtract_mean=True,
+        spatial_batch_size=100_000,
+        snapshot_batch_size=16,
+    )
+
+``spatial_batch_size`` controls how many values of the first spatial dimension
+are processed together.  ``snapshot_batch_size`` controls each request to the
+dataloader.  The TSQR accumulator still holds one spatial batch across all time
+steps, because the time dimension is the skinny dimension.  Its dominant
+working storage is therefore proportional to
+``spatial_batch_size * n_snapshots`` rather than the global spatial size.
+
+The built-in HDF5 and FOAM NumPy dataloaders read spatial slices directly.
+Other dataloaders inherit a compatible fallback that loads a snapshot before
+slicing it; custom loaders should override ``load_snapshot_slice`` to obtain
+true out-of-core I/O.
+
+Left singular vectors and physical reconstructions remain lazy.  Flat results
+are normalized; splitting restores the original component shapes and physical
+units::
+
+    for spatial_slice, result in svd.U.iter_chunks(split=True):
+        velocity_modes = result["U"]  # (local points, 3, rank)
+        pressure_modes = result["p"]  # (local points, rank)
+
+    reconstruction = svd.reconstruct(rank=20)
+    for spatial_slice, fields in reconstruction.iter_chunks(split=True):
+        write_fields(spatial_slice, fields)
+
+Call ``materialize_local`` only when the rank-local result fits in memory.
+
+Spatially distributed execution
+-------------------------------
+
+Initialize ``torch.distributed`` before constructing
+:class:`~flowtorch.analysis.statistics.DistributedExecution`.  Every process
+opens the same logical source and retains the full time dimension; flowTorch
+partitions only the first spatial dimension.  Rank-local QR factors are merely
+``n_snapshots`` square, and are merged collectively before the small SVD::
+
+    import os
+    import torch
+    import torch.distributed as dist
+    from flowtorch.analysis import DistributedExecution, SVD
+
+    dist.init_process_group(backend="nccl")  # use "gloo" on CPUs
+    local_rank = int(os.environ["LOCAL_RANK"])
+    torch.cuda.set_device(local_rank)
+
+    execution = DistributedExecution(root_rank=0)
+    source = DataloaderStateVectorSource(
+        loader,
+        fields,
+        normalization={"U": 20.0, "p": 100_000.0},
+        device=f"cuda:{local_rank}",
+    )
+    svd = SVD(
+        source,
+        rank=40,
+        spatial_batch_size=100_000,
+        snapshot_batch_size=16,
+        execution=execution,
+    )
+
+    # This is collective. Only root_rank receives the complete CPU tensor.
+    global_modes = svd.U.gather(root_rank=0)
+    dist.destroy_process_group()
+
+Use Gloo for portable CPU execution on Linux, macOS, and Windows.  NCCL is for
+NVIDIA GPUs and MPI is available when the installed PyTorch build includes it.
+Backend and launcher availability still depends on the local PyTorch build and
+cluster configuration.
+
+A minimal multi-node Slurm launch for one process per GPU is::
+
+    #!/bin/bash
+    #SBATCH --nodes=2
+    #SBATCH --ntasks-per-node=4
+    #SBATCH --gpus-per-node=4
+    #SBATCH --cpus-per-task=8
+
+    export OMP_NUM_THREADS=$SLURM_CPUS_PER_TASK
+    export MASTER_ADDR=$(scontrol show hostnames "$SLURM_JOB_NODELIST" | head -n 1)
+    export MASTER_PORT=29500
+
+    srun python distributed_spod.py
+
+This is hybrid parallelism: distributed ranks partition space across nodes and
+GPUs, while dataloader work and PyTorch kernels can use the CPUs assigned to
+each process.  Configure the script's global rank, local rank, and world size
+from Slurm's ``SLURM_PROCID``, ``SLURM_LOCALID``, and ``SLURM_NTASKS`` when the
+site's ``srun`` integration does not populate the variables expected by
+``init_process_group``.
+
+Updating a decomposition
+------------------------
+
+Construct a compatible source for new times and append it through the same API
+on every rank::
+
+    new_source = source.with_times(new_times)
+    svd.update(new_source)
+
+For an uncentered SVD, this performs an incremental distributed update and does
+not reread the original snapshots.  It is exact when the original SVD retained
+its complete rank and otherwise updates the retained approximation.  A centered
+update recomputes the decomposition out of core over the composite source so
+the changed global mean is exact.  Layout, spatial shape, normalization,
+weights, rank order, and collective call order must agree across ranks.
+
+Saving and loading
+------------------
+
+Checkpoints use an explicit, versioned dictionary rather than serializing the
+Python SVD or dataloader objects::
+
+    svd.save("svd.pt")
+
+    restored = SVD.load(
+        "svd.pt",
+        source=source,
+        execution=execution,
+        map_location=f"cuda:{local_rank}",
+    )
+
+A tensor-backed checkpoint contains the complete decomposition and can be
+loaded with ``SVD.load("svd.pt")``.  A source-backed checkpoint stores compact
+singular and temporal factors, state layout, normalization, and batch metadata,
+but deliberately omits the tall left modes and the dataloader.  Loading it
+therefore requires a compatible source; no snapshots are read until a lazy
+spatial result is evaluated.  A source recreated with ``normalization="rms"``
+receives the saved, frozen factors during loading without rescanning snapshots.
+
+In distributed execution, ``save`` is collective: the configured root writes
+one checkpoint on a shared filesystem and all ranks synchronize.  Every rank
+then calls ``load`` with its local execution configuration.  On GPUs,
+``map_location`` should match the device used by that rank's source.
+
+PAMSPOD and an existing SVD
+---------------------------
+
+PAMSPOD accepts the same lazy source directly::
+
+    spod = PAMSPOD(
+        source,
+        dt=0.001,
+        rank=40,
+        spatial_batch_size=100_000,
+        snapshot_batch_size=16,
+        execution=execution,
+    )
+
+When an SVD already exists, reuse its temporal factors without reloading the
+physical snapshots::
+
+    spod = PAMSPOD.from_svd(
+        svd,
+        dt=0.001,
+        adaptive=True,
+        keep_n_modes=3,
+    )
+
+The reduced PAMSPOD calculation is replicated on the ranks; large spatial modes
+and reconstructions stay distributed and lazy.  For source-backed results,
+``spod.modes`` has flat state-first order ``(state, frequency, mode)``.
+``get_mode``, ``mode_reconstruction``, and ``partial_reconstruction`` all return
+lazy results that support ``iter_chunks(split=True)`` and restore velocity,
+pressure, and other original fields.

--- a/docs/source/flowtorch.analysis.rst
+++ b/docs/source/flowtorch.analysis.rst
@@ -9,6 +9,14 @@ flowtorch.analysis.svd
    :undoc-members:
    :show-inheritance:
 
+flowtorch.analysis.state\_vector
+---------------------------------
+
+.. automodule:: flowtorch.analysis.state_vector
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 flowtorch.analysis.dft
 ----------------------
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -10,6 +10,7 @@ the Python :term:`API`.
 
    overview/glossary
    snapshot_statistics
+   distributed_svd_spod
    notebooks/linear_algebra_basics
    notebooks/svd_ht
    notebooks/ipsp_explorer

--- a/flowtorch/analysis/__init__.py
+++ b/flowtorch/analysis/__init__.py
@@ -18,6 +18,13 @@ from .linear_model import LinearModel
 from .dft import DFT, PDFT
 from .spod import AMSPOD, PAMSPOD, mode_similarity
 from .periodogram import AMPS
+from .state_vector import (
+    DataloaderStateVectorSource,
+    FieldSpec,
+    StateVectorLayout,
+    StateVectorResult,
+    StateVectorSource,
+)
 from .statistics import (
     DEFAULT_QUANTILES,
     STATISTIC_NAMES,
@@ -47,6 +54,8 @@ __all__ = [
     "DistributedExecution",
     "DFT",
     "DMD",
+    "DataloaderStateVectorSource",
+    "FieldSpec",
     "HODMD",
     "HOOptDMD",
     "HistogramResult",
@@ -74,6 +83,9 @@ __all__ = [
     "spatiotemporal_histogram",
     "statistical_moments",
     "STATISTIC_NAMES",
+    "StateVectorLayout",
+    "StateVectorResult",
+    "StateVectorSource",
     "subspace_similarity",
     "detect_linear_trend",
     "linear_trend",

--- a/flowtorch/analysis/spod.py
+++ b/flowtorch/analysis/spod.py
@@ -19,7 +19,7 @@ lightweight derived class wrapping around the `AMSPOD`, termed `PAMSPOD`.
 import logging
 import gc
 import warnings
-from typing import Any, Literal, Union, Tuple
+from typing import Any, Literal, Optional, Union, Tuple
 from math import sqrt
 from collections import defaultdict
 
@@ -29,6 +29,8 @@ from numpy import pi
 
 # flowTorch packages
 from .svd import SVD, _prepare_weight
+from .state_vector import StateVectorResult, StateVectorSource
+from .statistics import DistributedExecution
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
@@ -1033,11 +1035,27 @@ class AMSPOD(object):
 
 
 class PAMSPOD(AMSPOD):
-    """Perform AMSPOD on POD time coefficients."""
+    """Perform AMSPOD on POD time coefficients.
+
+    Tensor inputs retain the original in-memory behavior.  Passing a
+    :class:`~flowtorch.analysis.state_vector.StateVectorSource` uses the same
+    spatially batched and optionally distributed SVD interface::
+
+        spod = PAMSPOD(
+            source,
+            dt=0.001,
+            rank=40,
+            spatial_batch_size=100_000,
+            snapshot_batch_size=16,
+            execution=execution,
+        )
+        for spatial_slice, fields in spod.get_mode(5).iter_chunks(split=True):
+            velocity_mode = fields["U"]
+    """
 
     def __init__(
         self,
-        data_matrix: pt.Tensor,
+        data_matrix: Union[pt.Tensor, StateVectorSource],
         dt: float,
         nfft: Union[int, None] = None,
         adaptive: bool = True,
@@ -1049,6 +1067,9 @@ class PAMSPOD(AMSPOD):
         device: str = "cpu",
         verbose: bool = False,
         rank: Union[int, None] = None,
+        spatial_batch_size: Optional[int] = None,
+        snapshot_batch_size: Optional[int] = None,
+        execution: Optional[DistributedExecution] = None,
     ):
         """Perform POD-projection and compute AMSPOD.
 
@@ -1086,18 +1107,93 @@ class PAMSPOD(AMSPOD):
         :param rank: size of POD basis; if None, the full basis is used; defaults to None
         :type rank: int, optional
         """
-        self._dm_org = data_matrix
-        data_matrix_svd = data_matrix
-        if subtract_mean:
-            logger.info("subtracting temporal mean from original data matrix")
-            self._mean_org = data_matrix.mean(dim=-1)
-            data_matrix_svd = data_matrix - self._mean_org.unsqueeze(-1)
         if rank is None:
-            rank = min(data_matrix_svd.shape)
+            rank = (
+                min(data_matrix.shape)
+                if isinstance(data_matrix, pt.Tensor)
+                else min(data_matrix.layout.state_size, data_matrix.n_snapshots)
+            )
         logger.info("computing SVD of original data matrix")
-        self._svd = SVD(data_matrix_svd, rank, weight=weight)
-        super(PAMSPOD, self).__init__(
-            (self._svd.V * self._svd.s).T,
+        svd = SVD(
+            data_matrix,
+            rank,
+            weight=weight,
+            subtract_mean=subtract_mean,
+            spatial_batch_size=spatial_batch_size,
+            snapshot_batch_size=snapshot_batch_size,
+            execution=execution,
+        )
+        self._initialize_from_svd(
+            svd,
+            dt=dt,
+            nfft=nfft,
+            adaptive=adaptive,
+            max_tapers=max_tapers,
+            tolerance=tolerance,
+            keep_n_modes=keep_n_modes,
+            device=device,
+            verbose=verbose,
+        )
+
+    @classmethod
+    def from_svd(
+        cls,
+        svd: SVD,
+        dt: float,
+        nfft: Union[int, None] = None,
+        adaptive: bool = True,
+        max_tapers: int = 50,
+        tolerance: float = 1.0e-5,
+        keep_n_modes: int = 3,
+        device: str = "cpu",
+        verbose: bool = False,
+    ) -> "PAMSPOD":
+        """Construct PAMSPOD from an existing serial or distributed SVD.
+
+        The SVD's temporal factors, centering, normalization, state layout,
+        and spatial partition are reused without loading physical snapshots.
+
+        This avoids another SVD and does not read the physical snapshots while
+        constructing PAMSPOD::
+
+            svd = SVD(source, rank=20, subtract_mean=True, execution=execution)
+            spod = PAMSPOD.from_svd(svd, dt=0.001, keep_n_modes=3)
+        """
+        if not isinstance(svd, SVD):
+            raise ValueError("svd must be an SVD instance")
+        instance = cls.__new__(cls)
+        instance._initialize_from_svd(
+            svd,
+            dt,
+            nfft,
+            adaptive,
+            max_tapers,
+            tolerance,
+            keep_n_modes,
+            device,
+            verbose,
+        )
+        return instance
+
+    def _initialize_from_svd(
+        self,
+        svd: SVD,
+        dt: float,
+        nfft: Union[int, None],
+        adaptive: bool,
+        max_tapers: int,
+        tolerance: float,
+        keep_n_modes: int,
+        device: str,
+        verbose: bool,
+    ) -> None:
+        self._svd = svd
+        reduced_data = self._svd.s.unsqueeze(-1).type(self._svd.V.dtype) * (
+            self._svd.V.conj().T
+        )
+        AMSPOD.__init__(
+            self,
+            reduced_data,
             dt=dt,
             nfft=nfft,
             adaptive=adaptive,
@@ -1111,14 +1207,30 @@ class PAMSPOD(AMSPOD):
         )
 
     @property
-    def modes(self) -> pt.Tensor:
+    def modes(self) -> Union[pt.Tensor, StateVectorResult]:
         """Project modes back to the original physical space.
 
         :return: SPOD modes in full state space
         :rtype: pt.Tensor
         """
         m = super().modes
-        return pt.einsum("mr,nrk->nmk", self._svd.U.type(m.dtype), m)
+        basis = self._svd.U
+        if isinstance(basis, pt.Tensor):
+            return pt.einsum("mr,nrk->nmk", basis.type(m.dtype), m)
+
+        def produce(spatial_slice: slice) -> pt.Tensor:
+            local_basis = basis.read_chunk(spatial_slice)
+            assert isinstance(local_basis, pt.Tensor)
+            return pt.einsum("xr,frk->xfk", local_basis.type(m.dtype), m)
+
+        return StateVectorResult(
+            basis.layout,
+            basis.local_spatial_slice,
+            (m.shape[0], m.shape[2]),
+            produce,
+            basis.spatial_batch_size,
+            basis.execution,
+        )
 
     @property
     def svd(self) -> SVD:
@@ -1129,7 +1241,9 @@ class PAMSPOD(AMSPOD):
         """
         return self._svd
 
-    def get_mode(self, f_idx: int, mode_idx: int = 0) -> pt.Tensor:
+    def get_mode(
+        self, f_idx: int, mode_idx: int = 0
+    ) -> Union[pt.Tensor, StateVectorResult]:
         """Get mode/eigenvector of prescribed frequency bin and mode index.
 
         :param f_idx: index of the frequency bin
@@ -1140,7 +1254,23 @@ class PAMSPOD(AMSPOD):
         :rtype: pt.Tensor
         """
         mode = super().modes[f_idx, :, mode_idx]
-        return (self.svd.U.type(mode.dtype) * mode).sum(dim=1)
+        basis = self.svd.U
+        if isinstance(basis, pt.Tensor):
+            return (basis.type(mode.dtype) * mode).sum(dim=1)
+
+        def produce(spatial_slice: slice) -> pt.Tensor:
+            local_basis = basis.read_chunk(spatial_slice)
+            assert isinstance(local_basis, pt.Tensor)
+            return local_basis.type(mode.dtype) @ mode
+
+        return StateVectorResult(
+            basis.layout,
+            basis.local_spatial_slice,
+            (),
+            produce,
+            basis.spatial_batch_size,
+            basis.execution,
+        )
 
     def mode_reconstruction(
         self,
@@ -1148,7 +1278,7 @@ class PAMSPOD(AMSPOD):
         eig_idx: int = 0,
         dt: Union[float, None] = None,
         N: Union[int, None] = None,
-    ) -> pt.Tensor:
+    ) -> Union[pt.Tensor, StateVectorResult]:
         """Compute time-domain reconstruction based on a single mode.
 
         This method wraps around the corresponding method of the base class
@@ -1168,7 +1298,23 @@ class PAMSPOD(AMSPOD):
         :rtype: pt.Tensor
         """
         rec = super().mode_reconstruction(f_idx, eig_idx, dt, N)
-        return self.svd.U.type(rec.dtype) @ rec
+        basis = self.svd.U
+        if isinstance(basis, pt.Tensor):
+            return basis.type(rec.dtype) @ rec
+
+        def produce(spatial_slice: slice) -> pt.Tensor:
+            local_basis = basis.read_chunk(spatial_slice)
+            assert isinstance(local_basis, pt.Tensor)
+            return local_basis.type(rec.dtype) @ rec
+
+        return StateVectorResult(
+            basis.layout,
+            basis.local_spatial_slice,
+            (rec.shape[1],),
+            produce,
+            basis.spatial_batch_size,
+            basis.execution,
+        )
 
     def partial_reconstruction(
         self,
@@ -1178,7 +1324,7 @@ class PAMSPOD(AMSPOD):
         start_idx: int = 0,
         n_snapshots: int = 100,
         add_mean: bool = False,
-    ) -> pt.Tensor:
+    ) -> Union[pt.Tensor, StateVectorResult]:
         """Reconstruct snapshots in full space from selected bins and modes.
 
         See :meth:`AMSPOD.partial_reconstruction` for the argument definitions.
@@ -1189,7 +1335,35 @@ class PAMSPOD(AMSPOD):
         rec = super().partial_reconstruction(
             f_min, f_max, n_modes, start_idx, n_snapshots, add_mean=False
         )
-        rec = self.svd.U.type(rec.dtype) @ rec
-        if add_mean and hasattr(self, "_mean_org"):
-            rec += self._mean_org.unsqueeze(-1)
-        return rec
+        basis = self.svd.U
+        mean = self.svd.mean
+        if add_mean and mean is None:
+            raise RuntimeError(
+                "add_mean requires an SVD constructed with subtract_mean=True"
+            )
+        if isinstance(basis, pt.Tensor):
+            result = basis.type(rec.dtype) @ rec
+            if add_mean:
+                assert isinstance(mean, pt.Tensor)
+                result += mean.unsqueeze(-1)
+            return result
+
+        def produce(spatial_slice: slice) -> pt.Tensor:
+            local_basis = basis.read_chunk(spatial_slice)
+            assert isinstance(local_basis, pt.Tensor)
+            result = local_basis.type(rec.dtype) @ rec
+            if add_mean:
+                assert isinstance(mean, StateVectorResult)
+                local_mean = mean.read_chunk(spatial_slice)
+                assert isinstance(local_mean, pt.Tensor)
+                result += local_mean.unsqueeze(-1)
+            return result
+
+        return StateVectorResult(
+            basis.layout,
+            basis.local_spatial_slice,
+            (rec.shape[1],),
+            produce,
+            basis.spatial_batch_size,
+            basis.execution,
+        )

--- a/flowtorch/analysis/state_vector.py
+++ b/flowtorch/analysis/state_vector.py
@@ -1,0 +1,671 @@
+"""Lazy construction and decomposition outputs for physical state vectors."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from math import prod
+from numbers import Real
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Iterator,
+    Mapping,
+    Optional,
+    Sequence,
+    Union,
+    cast,
+)
+
+import torch as pt
+import torch.distributed as dist
+
+if TYPE_CHECKING:
+    from flowtorch.data.dataloader import Dataloader
+
+
+@dataclass(frozen=True)
+class FieldSpec:
+    """Describe one physical field in a flat state vector.
+
+    Component dimensions must trail the common spatial dimensions. All spatial
+    values of one component are stored contiguously before the next component.
+
+    >>> velocity = FieldSpec("U", component_shape=(3,), component_names=("u", "v", "w"))
+    >>> pressure = FieldSpec("p")
+    """
+
+    name: str
+    component_shape: tuple[int, ...] = ()
+    component_names: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if not self.name:
+            raise ValueError("field name must not be empty")
+        shape = tuple(int(value) for value in self.component_shape)
+        if any(value < 1 for value in shape):
+            raise ValueError("component_shape must contain positive dimensions")
+        names = tuple(self.component_names)
+        if names and len(names) != prod(shape):
+            raise ValueError(
+                "component_names must contain one name per tensor component"
+            )
+        object.__setattr__(self, "component_shape", shape)
+        object.__setattr__(self, "component_names", names)
+
+    @property
+    def n_components(self) -> int:
+        """Number of scalar components in the field."""
+        return prod(self.component_shape) if self.component_shape else 1
+
+
+class StateVectorLayout:
+    """Pack and restore fields using a stable component-major layout."""
+
+    def __init__(
+        self,
+        fields: Sequence[FieldSpec],
+        spatial_shape: Sequence[int],
+        normalization_factors: Optional[Mapping[str, float]] = None,
+    ) -> None:
+        self._fields = tuple(fields)
+        if not self._fields:
+            raise ValueError("at least one field is required")
+        if len({field.name for field in self._fields}) != len(self._fields):
+            raise ValueError("field names must be unique")
+        self._spatial_shape = tuple(int(value) for value in spatial_shape)
+        if not self._spatial_shape or any(value < 1 for value in self._spatial_shape):
+            raise ValueError("spatial_shape must contain positive dimensions")
+        factors = (
+            {field.name: 1.0 for field in self._fields}
+            if normalization_factors is None
+            else normalization_factors
+        )
+        if set(factors) != {field.name for field in self._fields}:
+            raise ValueError("normalization must define exactly one factor per field")
+        normalized: dict[str, float] = {}
+        for name, value in factors.items():
+            if not isinstance(value, Real) or isinstance(value, bool):
+                raise ValueError("normalization factors must be real scalars")
+            factor = float(value)
+            if not pt.isfinite(pt.tensor(factor)) or factor <= 0.0:
+                raise ValueError("normalization factors must be finite and positive")
+            normalized[name] = factor
+        self._normalization_factors = normalized
+
+    @property
+    def fields(self) -> tuple[FieldSpec, ...]:
+        return self._fields
+
+    @property
+    def spatial_shape(self) -> tuple[int, ...]:
+        return self._spatial_shape
+
+    @property
+    def normalization_factors(self) -> dict[str, float]:
+        return self._normalization_factors.copy()
+
+    @property
+    def state_size(self) -> int:
+        points = prod(self.spatial_shape)
+        return points * sum(field.n_components for field in self.fields)
+
+    @property
+    def signature(self) -> tuple[Any, ...]:
+        """Metadata used to validate compatible sources."""
+        return (
+            self.fields,
+            self.spatial_shape,
+            tuple(self._normalization_factors.items()),
+        )
+
+    def with_normalization(self, factors: Mapping[str, float]) -> "StateVectorLayout":
+        return StateVectorLayout(self.fields, self.spatial_shape, factors)
+
+    def pack(
+        self,
+        values: Mapping[str, pt.Tensor],
+        *,
+        spatial_shape: Optional[Sequence[int]] = None,
+        normalize: bool = True,
+    ) -> pt.Tensor:
+        """Concatenate scalar components into state-by-snapshot form."""
+        shape = self.spatial_shape if spatial_shape is None else tuple(spatial_shape)
+        packed = []
+        trailing_shape = None
+        reference = None
+        for field in self.fields:
+            if field.name not in values:
+                raise ValueError(f"missing field {field.name!r}")
+            value = values[field.name]
+            base_shape = (*shape, *field.component_shape)
+            if tuple(value.shape[: len(base_shape)]) != base_shape:
+                raise ValueError(
+                    f"field {field.name!r} has incompatible shape {tuple(value.shape)}; "
+                    f"expected a prefix of {base_shape}"
+                )
+            trailing = tuple(value.shape[len(base_shape) :])
+            if trailing_shape is None:
+                trailing_shape = trailing
+                reference = value
+            elif trailing != trailing_shape:
+                raise ValueError("all fields must have matching trailing dimensions")
+            assert reference is not None
+            if value.dtype != reference.dtype or value.device != reference.device:
+                raise ValueError("all fields must have matching dtypes and devices")
+            n_spatial = len(shape)
+            n_component = len(field.component_shape)
+            n_trailing = len(trailing)
+            order = (
+                *range(n_spatial, n_spatial + n_component),
+                *range(n_spatial),
+                *range(n_spatial + n_component, n_spatial + n_component + n_trailing),
+            )
+            component_major = value.permute(order) if order else value
+            flat = component_major.reshape(prod(shape) * field.n_components, *trailing)
+            if normalize:
+                flat = flat / self._normalization_factors[field.name]
+            packed.append(flat)
+        return pt.cat(packed, dim=0)
+
+    def split(
+        self,
+        state: pt.Tensor,
+        *,
+        spatial_shape: Optional[Sequence[int]] = None,
+        denormalize: bool = True,
+    ) -> dict[str, pt.Tensor]:
+        """Restore physical field and component dimensions from a flat state."""
+        shape = self.spatial_shape if spatial_shape is None else tuple(spatial_shape)
+        trailing = tuple(state.shape[1:])
+        expected = prod(shape) * sum(field.n_components for field in self.fields)
+        if state.ndim < 1 or state.shape[0] != expected:
+            raise ValueError(
+                f"state has {state.shape[0] if state.ndim else 0} rows; expected {expected}"
+            )
+        result = {}
+        offset = 0
+        for field in self.fields:
+            rows = prod(shape) * field.n_components
+            value = state[offset : offset + rows]
+            offset += rows
+            value = value.reshape(*field.component_shape, *shape, *trailing)
+            n_component = len(field.component_shape)
+            n_spatial = len(shape)
+            n_trailing = len(trailing)
+            order = (
+                *range(n_component, n_component + n_spatial),
+                *range(n_component),
+                *range(n_component + n_spatial, n_component + n_spatial + n_trailing),
+            )
+            value = value.permute(order) if order else value
+            if denormalize:
+                value = value * self._normalization_factors[field.name]
+            result[field.name] = value
+        return result
+
+
+class StateVectorSource(ABC):
+    """Random-access, spatially chunked source of flat state vectors."""
+
+    @property
+    @abstractmethod
+    def n_snapshots(self) -> int: ...
+
+    @property
+    @abstractmethod
+    def layout(self) -> StateVectorLayout: ...
+
+    @property
+    def spatial_shape(self) -> tuple[int, ...]:
+        return self.layout.spatial_shape
+
+    @abstractmethod
+    def read(self, spatial_slice: slice, snapshot_slice: slice) -> pt.Tensor: ...
+
+    def read_weight(self, spatial_slice: slice) -> Optional[pt.Tensor]:
+        return None
+
+    def fit_normalization(
+        self,
+        spatial_slice: slice,
+        spatial_batch_size: int,
+        snapshot_batch_size: int,
+        execution: Any = None,
+    ) -> None:
+        """Fit deferred normalization, if any."""
+
+    def restore_normalization(self, factors: Mapping[str, float]) -> None:
+        """Restore checkpoint normalization or reject incompatible factors."""
+        if self.layout.normalization_factors != dict(factors):
+            raise ValueError("source normalization is incompatible")
+
+
+WeightSource = Union[pt.Tensor, Callable[[slice], pt.Tensor]]
+
+
+class DataloaderStateVectorSource(StateVectorSource):
+    """Build state-vector chunks lazily from a flowTorch dataloader.
+
+    Each physical field has one normalization factor, regardless of how many
+    scalar components it contains.  For example, all three velocity components
+    use ``u_ref`` while pressure uses ``p_ref``::
+
+        fields = (
+            FieldSpec("U", component_shape=(3,), component_names=("u", "v", "w")),
+            FieldSpec("p"),
+        )
+        source = DataloaderStateVectorSource(
+            loader,
+            fields,
+            times=loader.write_times,
+            normalization={"U": u_ref, "p": p_ref},
+            spatial_weight=loader.weights,
+        )
+
+    Passing ``normalization="rms"`` fits one weighted fluctuation RMS per
+    field during the first SVD.  Snapshot and spatial slices are requested from
+    the dataloader only when a decomposition or result chunk needs them.
+    """
+
+    def __init__(
+        self,
+        loader: Dataloader,
+        fields: Sequence[FieldSpec],
+        times: Optional[Sequence[str]] = None,
+        normalization: Optional[Union[str, Mapping[str, float]]] = None,
+        spatial_weight: Optional[WeightSource] = None,
+        device: Union[str, pt.device] = "cpu",
+    ) -> None:
+        self._loader = loader
+        self._fields = tuple(fields)
+        if not self._fields:
+            raise ValueError("at least one field is required")
+        self._times = list(loader.write_times if times is None else times)
+        if not self._times:
+            raise ValueError("at least one snapshot time is required")
+        spatial_shapes = []
+        for field in self._fields:
+            shape = tuple(loader.snapshot_shape(field.name, self._times[0]))
+            n_component = len(field.component_shape)
+            if n_component:
+                if shape[-n_component:] != field.component_shape:
+                    raise ValueError(
+                        f"field {field.name!r} shape {shape} does not end with "
+                        f"component shape {field.component_shape}"
+                    )
+                shape = shape[:-n_component]
+            spatial_shapes.append(shape)
+        if any(shape != spatial_shapes[0] for shape in spatial_shapes[1:]):
+            raise ValueError("all fields must share the same spatial shape")
+        if normalization is None:
+            if len(self._fields) > 1:
+                raise ValueError("multiple fields require normalization")
+            factors = {self._fields[0].name: 1.0}
+            self._fit_rms = False
+        elif isinstance(normalization, str):
+            if normalization != "rms":
+                raise ValueError("normalization must be a mapping or 'rms'")
+            factors = {field.name: 1.0 for field in self._fields}
+            self._fit_rms = True
+        else:
+            factors = dict(normalization)
+            self._fit_rms = False
+        self._layout = StateVectorLayout(self._fields, spatial_shapes[0], factors)
+        self._spatial_weight = spatial_weight
+        self._device = pt.device(device)
+
+    @property
+    def n_snapshots(self) -> int:
+        return len(self._times)
+
+    @property
+    def times(self) -> tuple[str, ...]:
+        return tuple(self._times)
+
+    @property
+    def layout(self) -> StateVectorLayout:
+        return self._layout
+
+    @property
+    def normalization_fitted(self) -> bool:
+        return not self._fit_rms
+
+    def _read_raw_fields(
+        self, spatial_slice: slice, snapshot_slice: slice
+    ) -> dict[str, pt.Tensor]:
+        start, stop, step = snapshot_slice.indices(self.n_snapshots)
+        if step != 1:
+            raise ValueError("snapshot_slice must have unit stride")
+        times = self._times[start:stop]
+        if not times:
+            raise ValueError("snapshot slice must not be empty")
+        names = [field.name for field in self._fields]
+        loaded = self._loader.load_snapshot_slice(names, times, spatial_slice)
+        assert isinstance(loaded, list)
+        fields = {}
+        for field, value in zip(self._fields, loaded):
+            expected_snapshot_ndim = len(self.spatial_shape) + len(
+                field.component_shape
+            )
+            if value.ndim == expected_snapshot_ndim:
+                if len(times) != 1:
+                    raise ValueError(
+                        f"field {field.name!r} is missing its snapshot dimension"
+                    )
+                value = value.unsqueeze(-1)
+            if value.ndim != expected_snapshot_ndim + 1 or value.shape[-1] != len(
+                times
+            ):
+                raise ValueError(
+                    f"field {field.name!r} returned incompatible batched shape "
+                    f"{tuple(value.shape)}"
+                )
+            fields[field.name] = value.to(self._device)
+        return fields
+
+    def read(self, spatial_slice: slice, snapshot_slice: slice) -> pt.Tensor:
+        if self._fit_rms:
+            raise RuntimeError("RMS normalization must be fitted before reading")
+        fields = self._read_raw_fields(spatial_slice, snapshot_slice)
+        start, stop, step = spatial_slice.indices(self.spatial_shape[0])
+        if step != 1:
+            raise ValueError("spatial_slice must have unit stride")
+        chunk_shape = (stop - start, *self.spatial_shape[1:])
+        return self.layout.pack(fields, spatial_shape=chunk_shape)
+
+    def read_weight(self, spatial_slice: slice) -> Optional[pt.Tensor]:
+        if self._spatial_weight is None:
+            return None
+        weight = (
+            self._spatial_weight(spatial_slice)
+            if callable(self._spatial_weight)
+            else self._spatial_weight[spatial_slice]
+        )
+        return weight.to(self._device)
+
+    def fit_normalization(
+        self,
+        spatial_slice: slice,
+        spatial_batch_size: int,
+        snapshot_batch_size: int,
+        execution: Any = None,
+    ) -> None:
+        if not self._fit_rms:
+            return
+        local_start, local_stop, _ = spatial_slice.indices(self.spatial_shape[0])
+        numerators = pt.zeros(len(self._fields), dtype=pt.float64, device=self._device)
+        denominators = pt.zeros_like(numerators)
+        for spatial_start in range(local_start, local_stop, spatial_batch_size):
+            spatial_stop = min(spatial_start + spatial_batch_size, local_stop)
+            current_slice = slice(spatial_start, spatial_stop)
+            sums = [None] * len(self._fields)
+            sums_squared = [None] * len(self._fields)
+            for snapshot_start in range(0, self.n_snapshots, snapshot_batch_size):
+                snapshot_stop = min(
+                    snapshot_start + snapshot_batch_size, self.n_snapshots
+                )
+                fields = self._read_raw_fields(
+                    current_slice, slice(snapshot_start, snapshot_stop)
+                )
+                for index, field in enumerate(self._fields):
+                    value = fields[field.name]
+                    accumulator_dtype = (
+                        pt.complex128 if pt.is_complex(value) else pt.float64
+                    )
+                    value = value.to(accumulator_dtype)
+                    batch_sum = value.sum(dim=-1)
+                    batch_squared = value.abs().square().sum(dim=-1)
+                    sums[index] = (
+                        batch_sum if sums[index] is None else sums[index] + batch_sum
+                    )
+                    sums_squared[index] = (
+                        batch_squared
+                        if sums_squared[index] is None
+                        else sums_squared[index] + batch_squared
+                    )
+            weight = self.read_weight(current_slice)
+            for index, field in enumerate(self._fields):
+                field_sum = sums[index]
+                field_sum_squared = sums_squared[index]
+                assert field_sum is not None and field_sum_squared is not None
+                variation = (
+                    field_sum_squared - field_sum.abs().square() / self.n_snapshots
+                )
+                variation = variation.clamp_min(0.0)
+                if weight is None:
+                    numerators[index] += variation.sum()
+                    denominators[index] += self.n_snapshots * prod(
+                        variation.shape[: len(self.spatial_shape)]
+                    )
+                else:
+                    expanded = weight.to(pt.float64)
+                    for _ in field.component_shape:
+                        expanded = expanded.unsqueeze(-1)
+                    numerators[index] += (variation * expanded).sum()
+                    denominators[index] += (
+                        self.n_snapshots * weight.to(pt.float64).sum()
+                    )
+        if execution is not None:
+            group = execution.process_group
+            dist.all_reduce(numerators, op=dist.ReduceOp.SUM, group=group)
+            dist.all_reduce(denominators, op=dist.ReduceOp.SUM, group=group)
+        factors = (numerators / denominators).sqrt()
+        if not bool(pt.isfinite(factors).all()) or bool((factors <= 0.0).any()):
+            raise ValueError("cannot fit a positive finite RMS factor for every field")
+        self._layout = self.layout.with_normalization(
+            {
+                field.name: float(factors[index].item())
+                for index, field in enumerate(self._fields)
+            }
+        )
+        self._fit_rms = False
+
+    def restore_normalization(self, factors: Mapping[str, float]) -> None:
+        """Restore frozen factors without rescanning snapshots."""
+        if self._fit_rms:
+            self._layout = self.layout.with_normalization(factors)
+            self._fit_rms = False
+        else:
+            super().restore_normalization(factors)
+
+    def with_times(self, times: Sequence[str]) -> "DataloaderStateVectorSource":
+        """Create a compatible source for newly appended times."""
+        if self._fit_rms:
+            raise RuntimeError("normalization must be fitted first")
+        return DataloaderStateVectorSource(
+            self._loader,
+            self._fields,
+            times,
+            normalization=self.layout.normalization_factors,
+            spatial_weight=self._spatial_weight,
+            device=self._device,
+        )
+
+
+class CompositeStateVectorSource(StateVectorSource):
+    """Append-compatible view over consecutive state-vector sources."""
+
+    def __init__(self, sources: Sequence[StateVectorSource]) -> None:
+        self._sources = tuple(sources)
+        if not self._sources:
+            raise ValueError("at least one source is required")
+        signature = self._sources[0].layout.signature
+        if any(source.layout.signature != signature for source in self._sources[1:]):
+            raise ValueError("state-vector sources have incompatible layouts")
+        self._layout = self._sources[0].layout
+
+    @property
+    def n_snapshots(self) -> int:
+        return sum(source.n_snapshots for source in self._sources)
+
+    @property
+    def layout(self) -> StateVectorLayout:
+        return self._layout
+
+    def read(self, spatial_slice: slice, snapshot_slice: slice) -> pt.Tensor:
+        start, stop, step = snapshot_slice.indices(self.n_snapshots)
+        if step != 1 or start >= stop:
+            raise ValueError("snapshot_slice must be a non-empty unit-stride slice")
+        pieces = []
+        offset = 0
+        for source in self._sources:
+            source_stop = offset + source.n_snapshots
+            overlap_start = max(start, offset)
+            overlap_stop = min(stop, source_stop)
+            if overlap_start < overlap_stop:
+                pieces.append(
+                    source.read(
+                        spatial_slice,
+                        slice(overlap_start - offset, overlap_stop - offset),
+                    )
+                )
+            offset = source_stop
+        return pt.cat(pieces, dim=1)
+
+    def read_weight(self, spatial_slice: slice) -> Optional[pt.Tensor]:
+        return self._sources[0].read_weight(spatial_slice)
+
+
+class StateVectorResult:
+    """Lazy local spatial result with optional field reconstruction.
+
+    Flat chunks remain normalized.  Set ``split=True`` to obtain denormalized
+    physical fields with their original component dimensions::
+
+        for spatial_slice, fields in svd.U.iter_chunks(split=True):
+            velocity_modes = fields["U"]
+            pressure_modes = fields["p"]
+
+    Distributed results remain local unless :meth:`gather` is called
+    collectively on every rank.
+    """
+
+    def __init__(
+        self,
+        layout: StateVectorLayout,
+        local_spatial_slice: slice,
+        trailing_shape: Sequence[int],
+        producer: Callable[[slice], pt.Tensor],
+        spatial_batch_size: int,
+        execution: Any = None,
+    ) -> None:
+        self.layout = layout
+        self.local_spatial_slice = local_spatial_slice
+        self.trailing_shape = tuple(trailing_shape)
+        self._producer = producer
+        self.spatial_batch_size = spatial_batch_size
+        self.execution = execution
+
+    @property
+    def global_shape(self) -> tuple[int, ...]:
+        return (self.layout.state_size, *self.trailing_shape)
+
+    def read_chunk(
+        self, spatial_slice: slice, split: bool = False
+    ) -> Union[pt.Tensor, dict[str, pt.Tensor]]:
+        """Evaluate one spatial chunk within the rank-local partition."""
+        local_start, local_stop, _ = self.local_spatial_slice.indices(
+            self.layout.spatial_shape[0]
+        )
+        start, stop, step = spatial_slice.indices(self.layout.spatial_shape[0])
+        if step != 1 or start < local_start or stop > local_stop or start >= stop:
+            raise ValueError("spatial slice must be a non-empty rank-local interval")
+        value = self._producer(slice(start, stop))
+        if not split:
+            return value
+        chunk_shape = (stop - start, *self.layout.spatial_shape[1:])
+        return self.layout.split(value, spatial_shape=chunk_shape)
+
+    def iter_chunks(
+        self, split: bool = False
+    ) -> Iterator[tuple[slice, Union[pt.Tensor, dict[str, pt.Tensor]]]]:
+        start, stop, _ = self.local_spatial_slice.indices(self.layout.spatial_shape[0])
+        for chunk_start in range(start, stop, self.spatial_batch_size):
+            chunk_stop = min(chunk_start + self.spatial_batch_size, stop)
+            current = slice(chunk_start, chunk_stop)
+            yield current, self.read_chunk(current, split=split)
+
+    def materialize_local(
+        self, split: bool = False
+    ) -> Union[pt.Tensor, dict[str, pt.Tensor]]:
+        chunks = []
+        for spatial_slice, value in self.iter_chunks(split=False):
+            assert isinstance(value, pt.Tensor)
+            start, stop, _ = spatial_slice.indices(self.layout.spatial_shape[0])
+            chunks.append(
+                self.layout.split(
+                    value,
+                    spatial_shape=(stop - start, *self.layout.spatial_shape[1:]),
+                    denormalize=split,
+                )
+            )
+        if not chunks:
+            raise RuntimeError("this rank owns no spatial values")
+        fields = {
+            field.name: pt.cat([chunk[field.name] for chunk in chunks], dim=0)
+            for field in self.layout.fields
+        }
+        if split:
+            return fields
+        start, stop, _ = self.local_spatial_slice.indices(self.layout.spatial_shape[0])
+        local_shape = (stop - start, *self.layout.spatial_shape[1:])
+        return self.layout.pack(fields, spatial_shape=local_shape, normalize=False)
+
+    def gather(
+        self, split: bool = False, root_rank: Optional[int] = None
+    ) -> Optional[Union[pt.Tensor, dict[str, pt.Tensor]]]:
+        """Materialize local chunks and gather complete CPU fields on one rank."""
+        local = self.materialize_local(split=False)
+        start, stop, _ = self.local_spatial_slice.indices(self.layout.spatial_shape[0])
+        local_shape = (stop - start, *self.layout.spatial_shape[1:])
+        local = self.layout.split(local, spatial_shape=local_shape, denormalize=False)
+        assert isinstance(local, dict)
+        local_cpu = {name: value.detach().cpu() for name, value in local.items()}
+        if self.execution is None or not dist.is_initialized():
+            if split:
+                return local_cpu
+            return self.layout.pack(local_cpu, normalize=False)
+        group = self.execution.process_group
+        rank = dist.get_rank(group)
+        world_size = dist.get_world_size(group)
+        root = self.execution.root_rank if root_rank is None else root_rank
+        if root < 0 or root >= world_size:
+            raise ValueError("root_rank must identify a rank in the process group")
+        global_ranks = [None] * world_size
+        dist.all_gather_object(global_ranks, dist.get_rank(), group=group)
+        gathered = [None] * world_size if rank == root else None
+        dist.gather_object(
+            local_cpu,
+            gathered,
+            dst=global_ranks[root],
+            group=group,
+        )
+        if rank != root:
+            return None
+        assert gathered is not None
+        if any(part is None for part in gathered):
+            raise RuntimeError("distributed result gather is incomplete")
+        complete_parts = cast(list[dict[str, pt.Tensor]], gathered)
+        fields = {
+            field.name: pt.cat([part[field.name] for part in complete_parts], dim=0)
+            for field in self.layout.fields
+        }
+        if split:
+            return {
+                field.name: fields[field.name]
+                * self.layout.normalization_factors[field.name]
+                for field in self.layout.fields
+            }
+        return self.layout.pack(fields, normalize=False)
+
+
+__all__ = [
+    "CompositeStateVectorSource",
+    "DataloaderStateVectorSource",
+    "FieldSpec",
+    "StateVectorLayout",
+    "StateVectorResult",
+    "StateVectorSource",
+]

--- a/flowtorch/analysis/svd.py
+++ b/flowtorch/analysis/svd.py
@@ -4,19 +4,71 @@
 import logging
 from math import isfinite, sqrt
 from numbers import Integral, Real
-from typing import NamedTuple, Sequence, Tuple, Union
+from os import PathLike
+from typing import Any, NamedTuple, Optional, Sequence, Tuple, Union
 
 # third party packages
 import torch as pt
+import torch.distributed as dist
 
 # flowtorch packages
 from flowtorch.utils import format_byte_size
+from .state_vector import (
+    CompositeStateVectorSource,
+    StateVectorResult,
+    StateVectorSource,
+)
+from .statistics import DistributedExecution
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
 
 
-MODES = ("auto", "svd", "evd")
+MODES = ("auto", "svd", "evd", "tsqr")
+SVD_CHECKPOINT_VERSION = 1
+
+
+def _partition_spatial_axis(size: int, rank: int, world_size: int) -> tuple[int, int]:
+    """Return a balanced contiguous first-axis partition."""
+    common, remainder = divmod(size, world_size)
+    start = rank * common + min(rank, remainder)
+    stop = start + common + (1 if rank < remainder else 0)
+    return start, stop
+
+
+def _iter_slices(start: int, stop: int, batch_size: int):
+    for current in range(start, stop, batch_size):
+        yield slice(current, min(current + batch_size, stop))
+
+
+def _merge_triangular(first: Optional[pt.Tensor], second: pt.Tensor) -> pt.Tensor:
+    """Merge two TSQR triangular factors."""
+    if first is None:
+        return pt.linalg.qr(second, mode="r").R
+    return pt.linalg.qr(pt.cat((first, second), dim=0), mode="r").R
+
+
+def _reduce_triangular(
+    local: pt.Tensor,
+    execution: Optional[DistributedExecution],
+) -> pt.Tensor:
+    """Merge rank-local factors identically on every rank.
+
+    The factors are only snapshot-by-snapshot in size.  Using ``all_gather``
+    keeps this collective portable across Gloo, MPI, and NCCL while the tall
+    spatial factors remain distributed and out of core.
+    """
+    if execution is None:
+        return local
+    group = execution.process_group
+    world_size = dist.get_world_size(group)
+    gathered = [pt.empty_like(local) for _ in range(world_size)]
+    dist.all_gather(gathered, local, group=group)
+    factor = None
+    for current in gathered:
+        factor = _merge_triangular(factor, current)
+    assert factor is not None
+    return factor
 
 
 class PODSubspaceDependencyResult(NamedTuple):
@@ -392,15 +444,41 @@ class SVD(object):
     >>> svd.s_cum
     tensor([ 99.9687,  99.9996,  99.9999, 100.0000, 100.0000])
     >>> svd.U.shape
-    torch.Size([100, 5])
+    torch.Size([400, 5])
+
+    A :class:`~flowtorch.analysis.state_vector.StateVectorSource` selects the
+    out-of-core TSQR path.  The same call is spatially distributed when an
+    initialized :class:`~flowtorch.analysis.statistics.DistributedExecution`
+    is supplied::
+
+        source = DataloaderStateVectorSource(
+            loader,
+            (FieldSpec("U", (3,)), FieldSpec("p")),
+            normalization={"U": u_ref, "p": p_ref},
+        )
+        svd = SVD(
+            source,
+            rank=20,
+            subtract_mean=True,
+            spatial_batch_size=100_000,
+            snapshot_batch_size=16,
+            execution=execution,  # omit for shared-memory execution
+        )
+        for spatial_slice, fields in svd.U.iter_chunks(split=True):
+            consume(fields["U"], fields["p"])
     """
 
     def __init__(
         self,
-        data_matrix: pt.Tensor,
+        data_matrix: Union[pt.Tensor, StateVectorSource],
         rank: Union[int, None] = None,
         mode: str = "auto",
         weight: Union[pt.Tensor, None] = None,
+        *,
+        subtract_mean: bool = False,
+        spatial_batch_size: Optional[int] = None,
+        snapshot_batch_size: Optional[int] = None,
+        execution: Optional[DistributedExecution] = None,
     ):
         r"""Compute a truncated, optionally weighted SVD of a data matrix.
 
@@ -410,9 +488,10 @@ class SVD(object):
         Euclidean-orthonormal weighted-coordinate representation. Consequently,
         :meth:`reconstruct` always returns data in the original coordinates.
 
-        :param data_matrix: data matrix of shape M x N, typically with M being the
-            number of spatial points and N being the number of time steps
-        :type data_matrix: pt.Tensor
+        :param data_matrix: data matrix of shape M x N or a lazy state-vector
+            source. Lazy sources use out-of-core TSQR and partition the first
+            spatial dimension when ``execution`` is supplied.
+        :type data_matrix: Union[pt.Tensor, StateVectorSource]
         :param rank: rank at which to truncate the SVD; if no rank is given, the 'optimal'
             rank is determined via singular value hard thresholding; defaults to None
         :type rank: Union[int, None], optional
@@ -425,11 +504,43 @@ class SVD(object):
         :param weight: positive diagonal inner-product weight; a shorter vector
             is repeated when its length divides the state dimension
         :type weight: pt.Tensor, optional
+        :param subtract_mean: subtract and retain the temporal mean, defaults to
+            False
+        :param spatial_batch_size: maximum number of first-axis spatial values
+            loaded per rank and batch for a lazy source
+        :param snapshot_batch_size: maximum number of snapshots requested from
+            a lazy source at once
+        :param execution: distributed execution configuration. Every rank must
+            construct the same source; the spatial dimension is partitioned,
+            while time is retained on every rank.
         :raises ValueError:
             - if the data matrix does not have exactly two dimensions
             - if an invalid compute mode is specified
             - if the weight is invalid or incompatible with the state dimension
         """
+        if isinstance(data_matrix, StateVectorSource):
+            self._init_source(
+                data_matrix,
+                rank,
+                mode,
+                weight,
+                subtract_mean,
+                spatial_batch_size,
+                snapshot_batch_size,
+                execution,
+            )
+            return
+        if execution is not None:
+            raise ValueError(
+                "distributed SVD requires a StateVectorSource on every rank"
+            )
+        input_mean = data_matrix.mean(dim=1) if subtract_mean else None
+        if input_mean is not None:
+            data_matrix = data_matrix - input_mean.unsqueeze(-1)
+        self._source: Optional[StateVectorSource] = None
+        self._subtract_mean = subtract_mean
+        self._execution: Optional[DistributedExecution] = None
+        self._mean = input_mean
         shape = data_matrix.shape
         if len(shape) != 2:
             raise ValueError(
@@ -470,6 +581,219 @@ class SVD(object):
         self._U = U.contiguous()
         self._s = s[: self.rank].clone()
         self._V = V[:, : self.rank].contiguous()
+
+    @staticmethod
+    def _validate_batch_size(value: Optional[int], default: int, name: str) -> int:
+        selected = default if value is None else value
+        if (
+            not isinstance(selected, Integral)
+            or isinstance(selected, bool)
+            or selected < 1
+        ):
+            raise ValueError(f"{name} must be a positive integer")
+        return int(selected)
+
+    def _init_source(
+        self,
+        source: StateVectorSource,
+        rank: Optional[int],
+        mode: str,
+        weight: Optional[pt.Tensor],
+        subtract_mean: bool,
+        spatial_batch_size: Optional[int],
+        snapshot_batch_size: Optional[int],
+        execution: Optional[DistributedExecution],
+    ) -> None:
+        """Compute an out-of-core tall-skinny SVD."""
+        if mode not in ("auto", "tsqr"):
+            raise ValueError("StateVectorSource inputs require mode 'auto' or 'tsqr'")
+        if not isinstance(subtract_mean, bool):
+            raise ValueError("subtract_mean must be a boolean")
+        if execution is not None:
+            if not isinstance(execution, DistributedExecution):
+                raise ValueError("execution must be a DistributedExecution instance")
+            if not dist.is_available() or not dist.is_initialized():
+                raise RuntimeError("torch.distributed must be initialized")
+            group = execution.process_group
+            process_rank = dist.get_rank(group)
+            world_size = dist.get_world_size(group)
+            if execution.root_rank < 0 or execution.root_rank >= world_size:
+                raise ValueError("root_rank must identify a rank in the process group")
+        else:
+            process_rank = 0
+            world_size = 1
+        if world_size > source.spatial_shape[0]:
+            raise ValueError(
+                "the process group cannot contain more ranks than first-axis spatial values"
+            )
+        if weight is not None:
+            if tuple(weight.shape) != source.spatial_shape:
+                raise ValueError(
+                    "a source-backed weight must match the source spatial shape"
+                )
+            if weight.device.type != "cpu":
+                raise ValueError("source-backed global weights must be stored on CPU")
+        self._source = source
+        self._source_weight = weight
+        self._subtract_mean = subtract_mean
+        self._execution = execution
+        self._rows = source.layout.state_size
+        self._cols = source.n_snapshots
+        self._mode = "tsqr"
+        self._spatial_batch_size = self._validate_batch_size(
+            spatial_batch_size, min(1024, source.spatial_shape[0]), "spatial_batch_size"
+        )
+        self._snapshot_batch_size = self._validate_batch_size(
+            snapshot_batch_size, min(16, source.n_snapshots), "snapshot_batch_size"
+        )
+        start, stop = _partition_spatial_axis(
+            source.spatial_shape[0], process_rank, world_size
+        )
+        self._local_spatial_slice = slice(start, stop)
+        source.fit_normalization(
+            self._local_spatial_slice,
+            self._spatial_batch_size,
+            self._snapshot_batch_size,
+            execution,
+        )
+        self._fit_source_factors(rank)
+
+    def _source_block(
+        self,
+        source: StateVectorSource,
+        spatial_slice: slice,
+        *,
+        subtract_mean: Optional[bool] = None,
+    ) -> tuple[pt.Tensor, Optional[pt.Tensor]]:
+        """Load all temporal columns for one spatial chunk."""
+        pieces = []
+        for snapshot_slice in _iter_slices(
+            0, source.n_snapshots, self._snapshot_batch_size
+        ):
+            pieces.append(source.read(spatial_slice, snapshot_slice))
+        block = pt.cat(pieces, dim=1)
+        center = self._subtract_mean if subtract_mean is None else subtract_mean
+        mean = block.mean(dim=1) if center else None
+        if mean is not None:
+            block = block - mean.unsqueeze(-1)
+        return block, mean
+
+    def _weight_block(
+        self, source: StateVectorSource, spatial_slice: slice, reference: pt.Tensor
+    ) -> Optional[pt.Tensor]:
+        weight = source.read_weight(spatial_slice)
+        if weight is not None and self._source_weight is not None:
+            raise ValueError("weight is defined by both the source and SVD")
+        if weight is None and self._source_weight is not None:
+            weight = self._source_weight[spatial_slice].to(reference.device)
+        if weight is None:
+            return None
+        start, stop, _ = spatial_slice.indices(source.spatial_shape[0])
+        expected = (stop - start, *source.spatial_shape[1:])
+        if tuple(weight.shape) != expected:
+            raise ValueError(
+                f"spatial weight has shape {tuple(weight.shape)}; expected {expected}"
+            )
+        if pt.is_complex(weight) or weight.dtype == pt.bool:
+            raise ValueError("weight must have a real numeric dtype")
+        if not bool(pt.isfinite(weight).all()) or bool((weight <= 0.0).any()):
+            raise ValueError("weight values must be finite and positive")
+        repeats = sum(field.n_components for field in source.layout.fields)
+        return (
+            weight.reshape(-1)
+            .repeat(repeats)
+            .to(device=reference.device, dtype=reference.real.dtype)
+        )
+
+    def _weighted_block(
+        self, source: StateVectorSource, spatial_slice: slice, block: pt.Tensor
+    ) -> pt.Tensor:
+        weight = self._weight_block(source, spatial_slice, block)
+        return block if weight is None else block * weight.sqrt().unsqueeze(-1)
+
+    def _local_triangular_factor(
+        self,
+        source: StateVectorSource,
+        columns: int,
+        block_transform=None,
+    ) -> pt.Tensor:
+        """Accumulate one rank-local TSQR factor from spatial chunks."""
+        local_start, local_stop, _ = self._local_spatial_slice.indices(
+            source.spatial_shape[0]
+        )
+        triangular = None
+        reference = None
+        for spatial_slice in _iter_slices(
+            local_start, local_stop, self._spatial_batch_size
+        ):
+            block, _ = self._source_block(source, spatial_slice)
+            if block_transform is not None:
+                block = block_transform(spatial_slice, block)
+            block = self._weighted_block(source, spatial_slice, block)
+            reference = block
+            triangular = _merge_triangular(triangular, block)
+        if reference is None or triangular is None:
+            raise RuntimeError("the local spatial partition is empty")
+        padded = reference.new_zeros((columns, columns))
+        padded[: triangular.shape[0]] = triangular
+        return padded
+
+    def _fit_source_factors(self, requested_rank: Optional[int]) -> None:
+        assert self._source is not None
+        local = self._local_triangular_factor(self._source, self._cols)
+        triangular = _reduce_triangular(local, self._execution)
+        root = (
+            self._execution is None
+            or dist.get_rank(self._execution.process_group) == self._execution.root_rank
+        )
+        if root:
+            _, singular_values, right_h = pt.linalg.svd(triangular, full_matrices=False)
+            right = right_h.conj().T
+        else:
+            singular_values = triangular.real.new_empty(self._cols)
+            right = triangular.new_empty((self._cols, self._cols))
+        if self._execution is not None:
+            group = self._execution.process_group
+            global_ranks: list[Any] = [None] * dist.get_world_size(group)
+            dist.all_gather_object(global_ranks, dist.get_rank(), group=group)
+            root_global = global_ranks[self._execution.root_rank]
+            dist.broadcast(singular_values, src=root_global, group=group)
+            dist.broadcast(right, src=root_global, group=group)
+        self._opt_rank = self._optimal_rank(singular_values)
+        self.rank = self.opt_rank if requested_rank is None else requested_rank
+        self._s_full = singular_values
+        self._s = singular_values[: self.rank].clone().contiguous()
+        self._V = right[:, : self.rank].contiguous()
+        self._weight = None
+        self._sqrt_weight = None
+        self._mean = self._mean_result() if self._subtract_mean else None
+        logger.info(
+            f"Truncating TSQR SVD at index {self.rank}/{min(self._cols, self._rows)}"
+        )
+
+    def _left_chunk(self, spatial_slice: slice) -> pt.Tensor:
+        assert self._source is not None
+        block, _ = self._source_block(self._source, spatial_slice)
+        denominator = self.s.clamp_min(pt.finfo(self.s.dtype).eps * self.s[0])
+        return (block @ self.V) / denominator
+
+    def _mean_result(self) -> StateVectorResult:
+        assert self._source is not None
+        source = self._source
+
+        def produce(spatial_slice: slice) -> pt.Tensor:
+            _, mean = self._source_block(source, spatial_slice, subtract_mean=True)
+            assert mean is not None
+            return mean
+
+        return StateVectorResult(
+            source.layout,
+            self._local_spatial_slice,
+            (),
+            produce,
+            self._spatial_batch_size,
+            self._execution,
+        )
 
     def _svd(self, X: pt.Tensor) -> Tuple[pt.Tensor, pt.Tensor, pt.Tensor]:
         """Compute the economy SVD via the native SVD implementation.
@@ -537,7 +861,7 @@ class SVD(object):
         else:
             return closest
 
-    def reconstruct(self, rank: Union[int, None] = None) -> pt.Tensor:
+    def reconstruct(self, rank: Union[int, None] = None) -> Any:
         """Reconstruct the data matrix for a given rank.
 
         :param rank: rank used to compute a truncated reconstruction
@@ -546,10 +870,24 @@ class SVD(object):
         :rtype: pt.Tensor
         """
         r_rank = self.rank if rank is None else max(min(rank, self.rank), 1)
+        if self._source is not None:
+
+            def produce(spatial_slice: slice) -> pt.Tensor:
+                modes = self._left_chunk(spatial_slice)[:, :r_rank]
+                return (modes * self.s[:r_rank]) @ self.V[:, :r_rank].conj().T
+
+            return StateVectorResult(
+                self._source.layout,
+                self._local_spatial_slice,
+                (self._cols,),
+                produce,
+                self._spatial_batch_size,
+                self._execution,
+            )
         return (self.U[:, :r_rank] * self.s[:r_rank]) @ self.V[:, :r_rank].conj().T
 
     @property
-    def U(self) -> pt.Tensor:
+    def U(self) -> Any:
         r"""Physical left-singular vectors.
 
         For a weighted decomposition, these modes are orthonormal in the
@@ -558,10 +896,19 @@ class SVD(object):
         :return: physical left-singular vectors truncated to specified rank
         :rtype: pt.Tensor
         """
-        return self._U
+        if self._source is None:
+            return self._U
+        return StateVectorResult(
+            self._source.layout,
+            self._local_spatial_slice,
+            (self.rank,),
+            self._left_chunk,
+            self._spatial_batch_size,
+            self._execution,
+        )
 
     @property
-    def U_weighted(self) -> pt.Tensor:
+    def U_weighted(self) -> Union[pt.Tensor, StateVectorResult]:
         r"""Euclidean-orthonormal left-singular vectors.
 
         For a weighted decomposition, this is ``W**0.5 @ U``. Without a
@@ -570,6 +917,22 @@ class SVD(object):
         :return: left-singular vectors in weighted coordinates
         :rtype: pt.Tensor
         """
+        if self._source is not None:
+            source = self._source
+
+            def produce(spatial_slice: slice) -> pt.Tensor:
+                modes = self._left_chunk(spatial_slice)
+                weight = self._weight_block(source, spatial_slice, modes)
+                return modes if weight is None else modes * weight.sqrt().unsqueeze(-1)
+
+            return StateVectorResult(
+                source.layout,
+                self._local_spatial_slice,
+                (self.rank,),
+                produce,
+                self._spatial_batch_size,
+                self._execution,
+            )
         if self._sqrt_weight is None:
             return self._U
         return self._U * self._sqrt_weight
@@ -582,6 +945,11 @@ class SVD(object):
         :rtype: Union[pt.Tensor, None]
         """
         return self._weight
+
+    @property
+    def mean(self) -> Optional[Union[pt.Tensor, StateVectorResult]]:
+        """Temporal mean retained by a centered decomposition."""
+        return self._mean
 
     @property
     def s(self) -> pt.Tensor:
@@ -678,23 +1046,336 @@ class SVD(object):
         :return: cumulative size of truncated U, s, and V tensors in bytes
         :rtype: int
         """
-        memory = (
-            self.U.element_size() * self.U.nelement()
-            + self.s.element_size() * self.s.nelement()
-            + self.V.element_size() * self.V.nelement()
-        )
+        if self._source is None:
+            memory = self._U.element_size() * self._U.nelement()
+        else:
+            memory = 0
+        memory += self.s.element_size() * self.s.nelement()
+        memory += self.V.element_size() * self.V.nelement()
         if self.weight is not None:
             memory += self.weight.element_size() * self.weight.nelement()
         if self._sqrt_weight is not None:
             memory += self._sqrt_weight.element_size() * self._sqrt_weight.nelement()
         return memory
 
+    def update(self, new_source: StateVectorSource) -> "SVD":
+        """Append snapshots from a compatible lazy source.
+
+        Uncentered decompositions use a distributed incremental update. A
+        centered decomposition is recomputed out of core so that changing the
+        global mean is handled exactly.
+
+        The update modifies and returns this object::
+
+            new_source = source.with_times(new_times)
+            svd.update(new_source)
+            updated_singular_values = svd.s
+        """
+        if self._source is None:
+            raise RuntimeError("update requires a source-backed SVD")
+        if not isinstance(new_source, StateVectorSource):
+            raise ValueError("new_source must be a StateVectorSource")
+        if new_source.layout.signature != self._source.layout.signature:
+            raise ValueError("new source layout or normalization is incompatible")
+        if new_source.spatial_shape != self._source.spatial_shape:
+            raise ValueError("new source has an incompatible spatial shape")
+        combined = CompositeStateVectorSource((self._source, new_source))
+        selected_rank = self.rank
+        if self._subtract_mean:
+            self._source = combined
+            self._cols = combined.n_snapshots
+            self._fit_source_factors(selected_rank)
+            return self
+
+        old_source = self._source
+        old_columns = self._cols
+        added_columns = new_source.n_snapshots
+        cross = self.V.new_zeros((self.rank, added_columns))
+        local_start, local_stop, _ = self._local_spatial_slice.indices(
+            old_source.spatial_shape[0]
+        )
+        for spatial_slice in _iter_slices(
+            local_start, local_stop, self._spatial_batch_size
+        ):
+            old_modes = self._left_chunk(spatial_slice)
+            added, _ = self._source_block(
+                new_source, spatial_slice, subtract_mean=False
+            )
+            weight = self._weight_block(old_source, spatial_slice, old_modes)
+            if weight is None:
+                cross += old_modes.conj().T @ added
+            else:
+                cross += old_modes.conj().T @ (added * weight.unsqueeze(-1))
+        if self._execution is not None:
+            dist.all_reduce(
+                cross, op=dist.ReduceOp.SUM, group=self._execution.process_group
+            )
+
+        def residual(spatial_slice: slice, added: pt.Tensor) -> pt.Tensor:
+            return added - self._left_chunk(spatial_slice) @ cross
+
+        local_residual = self._local_triangular_factor(
+            new_source, added_columns, residual
+        )
+        residual_r = _reduce_triangular(local_residual, self._execution)
+        core_size = self.rank + added_columns
+        core = self.V.new_zeros((core_size, core_size))
+        core[: self.rank, : self.rank] = pt.diag(self.s).to(core.dtype)
+        core[: self.rank, self.rank :] = cross
+        core[self.rank :, self.rank :] = residual_r
+        root = (
+            self._execution is None
+            or dist.get_rank(self._execution.process_group) == self._execution.root_rank
+        )
+        if root:
+            _, updated_s, updated_vh = pt.linalg.svd(core, full_matrices=False)
+            updated_v = updated_vh.conj().T
+        else:
+            updated_s = core.real.new_empty(core_size)
+            updated_v = core.new_empty((core_size, core_size))
+        if self._execution is not None:
+            group = self._execution.process_group
+            global_ranks: list[Any] = [None] * dist.get_world_size(group)
+            dist.all_gather_object(global_ranks, dist.get_rank(), group=group)
+            root_global = global_ranks[self._execution.root_rank]
+            dist.broadcast(updated_s, src=root_global, group=group)
+            dist.broadcast(updated_v, src=root_global, group=group)
+        right_basis = self.V.new_zeros((old_columns + added_columns, core_size))
+        right_basis[:old_columns, : self.rank] = self.V
+        right_basis[old_columns:, self.rank :] = pt.eye(
+            added_columns, dtype=self.V.dtype, device=self.V.device
+        )
+        new_rank = min(selected_rank, updated_s.numel())
+        new_v = (right_basis @ updated_v[:, :new_rank]).contiguous()
+        self._source = combined
+        self._cols = combined.n_snapshots
+        self._s_full = updated_s
+        self._opt_rank = self._optimal_rank(updated_s)
+        self._rank = new_rank
+        self._s = updated_s[:new_rank].clone().contiguous()
+        self._V = new_v
+        self._mean = None
+        return self
+
+    @staticmethod
+    def _layout_metadata(source: StateVectorSource) -> dict[str, Any]:
+        """Convert state-vector metadata to checkpoint-safe built-in values."""
+        return {
+            "spatial_shape": list(source.layout.spatial_shape),
+            "fields": [
+                {
+                    "name": field.name,
+                    "component_shape": list(field.component_shape),
+                    "component_names": list(field.component_names),
+                }
+                for field in source.layout.fields
+            ],
+            "normalization_factors": source.layout.normalization_factors,
+        }
+
+    def save(self, path: Union[str, PathLike[str]]) -> None:
+        """Save a versioned SVD checkpoint.
+
+        Tensor-backed decompositions include the left modes and can be loaded
+        independently.  Source-backed decompositions store only compact
+        factors, layout metadata, and configuration; pass a compatible source
+        to :meth:`load` to restore their lazy modes and reconstructions.
+
+        In distributed execution this method is collective. Only the configured
+        root writes the shared path, then all ranks synchronize::
+
+            svd.save("svd.pt")
+            restored = SVD.load("svd.pt", source=source, execution=execution)
+        """
+        checkpoint: dict[str, Any] = {
+            "format": "flowtorch.svd",
+            "version": SVD_CHECKPOINT_VERSION,
+            "kind": "source" if self._source is not None else "tensor",
+            "rows": self._rows,
+            "cols": self._cols,
+            "rank": self.rank,
+            "opt_rank": self.opt_rank,
+            "mode": self.mode,
+            "subtract_mean": self._subtract_mean,
+            "s": self.s.detach().cpu(),
+            "s_full": self.s_full.detach().cpu(),
+            "V": self.V.detach().cpu(),
+        }
+        if self._source is None:
+            checkpoint.update(
+                {
+                    "U": self._U.detach().cpu(),
+                    "weight": (
+                        None if self._weight is None else self._weight.detach().cpu()
+                    ),
+                    "sqrt_weight": (
+                        None
+                        if self._sqrt_weight is None
+                        else self._sqrt_weight.detach().cpu()
+                    ),
+                    "mean": None if self._mean is None else self._mean.detach().cpu(),
+                }
+            )
+        else:
+            checkpoint.update(
+                {
+                    "layout": self._layout_metadata(self._source),
+                    "spatial_batch_size": self._spatial_batch_size,
+                    "snapshot_batch_size": self._snapshot_batch_size,
+                    "source_weight": (
+                        None
+                        if self._source_weight is None
+                        else self._source_weight.detach().cpu()
+                    ),
+                }
+            )
+        should_write = True
+        if self._execution is not None:
+            should_write = (
+                dist.get_rank(self._execution.process_group)
+                == self._execution.root_rank
+            )
+        if should_write:
+            pt.save(checkpoint, path)
+        if self._execution is not None:
+            dist.barrier(group=self._execution.process_group)
+
+    @classmethod
+    def load(
+        cls,
+        path: Union[str, PathLike[str]],
+        *,
+        source: Optional[StateVectorSource] = None,
+        execution: Optional[DistributedExecution] = None,
+        map_location: Any = "cpu",
+        spatial_batch_size: Optional[int] = None,
+        snapshot_batch_size: Optional[int] = None,
+    ) -> "SVD":
+        """Restore an SVD without recomputing its factors.
+
+        ``source`` is required for a source-backed checkpoint and must have the
+        same fields, component shapes, normalization factors, spatial shape,
+        and snapshot count.  Use ``map_location`` to place compact factors on
+        the device from which the source returns chunks.  The batch-size
+        arguments optionally override their saved values.
+
+        Loading does not read physical snapshots::
+
+            source = DataloaderStateVectorSource(
+                loader,
+                fields,
+                normalization=saved_normalization,
+            )
+            svd = SVD.load("svd.pt", source=source)
+        """
+        try:
+            checkpoint = pt.load(
+                path,
+                map_location=map_location,
+                weights_only=True,
+            )
+        except TypeError:  # PyTorch versions before ``weights_only``
+            checkpoint = pt.load(path, map_location=map_location)
+        if not isinstance(checkpoint, dict):
+            raise ValueError("invalid SVD checkpoint")
+        if checkpoint.get("format") != "flowtorch.svd":
+            raise ValueError("file is not a flowTorch SVD checkpoint")
+        if checkpoint.get("version") != SVD_CHECKPOINT_VERSION:
+            raise ValueError(
+                "unsupported SVD checkpoint version " f"{checkpoint.get('version')!r}"
+            )
+        kind = checkpoint.get("kind")
+        if kind not in ("tensor", "source"):
+            raise ValueError("invalid SVD checkpoint kind")
+        instance = cls.__new__(cls)
+        instance._rows = int(checkpoint["rows"])
+        instance._cols = int(checkpoint["cols"])
+        instance._rank = int(checkpoint["rank"])
+        instance._opt_rank = int(checkpoint["opt_rank"])
+        instance._mode = str(checkpoint["mode"])
+        instance._subtract_mean = bool(checkpoint["subtract_mean"])
+        instance._s = checkpoint["s"]
+        instance._s_full = checkpoint["s_full"]
+        instance._V = checkpoint["V"]
+        if kind == "tensor":
+            if source is not None or execution is not None:
+                raise ValueError(
+                    "source and execution are only valid for source-backed checkpoints"
+                )
+            instance._source = None
+            instance._execution = None
+            instance._U = checkpoint["U"]
+            instance._weight = checkpoint["weight"]
+            instance._sqrt_weight = checkpoint["sqrt_weight"]
+            instance._mean = checkpoint["mean"]
+            return instance
+        if source is None:
+            raise ValueError("source-backed checkpoints require a source")
+        saved_layout = checkpoint.get("layout")
+        if not isinstance(saved_layout, dict):
+            raise ValueError("source-backed checkpoint has invalid layout metadata")
+        saved_normalization = saved_layout.get("normalization_factors")
+        if not isinstance(saved_normalization, dict):
+            raise ValueError(
+                "source-backed checkpoint has invalid normalization metadata"
+            )
+        source.restore_normalization(saved_normalization)
+        if cls._layout_metadata(source) != saved_layout:
+            raise ValueError(
+                "source layout, component metadata, or normalization is incompatible"
+            )
+        if source.n_snapshots != instance._cols:
+            raise ValueError(
+                f"source has {source.n_snapshots} snapshots; expected {instance._cols}"
+            )
+        if execution is not None:
+            if not isinstance(execution, DistributedExecution):
+                raise ValueError("execution must be a DistributedExecution instance")
+            if not dist.is_available() or not dist.is_initialized():
+                raise RuntimeError("torch.distributed must be initialized")
+            group = execution.process_group
+            process_rank = dist.get_rank(group)
+            world_size = dist.get_world_size(group)
+            if execution.root_rank < 0 or execution.root_rank >= world_size:
+                raise ValueError("root_rank must identify a rank in the process group")
+        else:
+            process_rank = 0
+            world_size = 1
+        if world_size > source.spatial_shape[0]:
+            raise ValueError(
+                "the process group cannot contain more ranks than first-axis "
+                "spatial values"
+            )
+        instance._source = source
+        instance._execution = execution
+        instance._source_weight = checkpoint["source_weight"]
+        if instance._source_weight is not None:
+            instance._source_weight = instance._source_weight.cpu()
+        instance._weight = None
+        instance._sqrt_weight = None
+        instance._spatial_batch_size = cls._validate_batch_size(
+            spatial_batch_size,
+            int(checkpoint["spatial_batch_size"]),
+            "spatial_batch_size",
+        )
+        instance._snapshot_batch_size = cls._validate_batch_size(
+            snapshot_batch_size,
+            int(checkpoint["snapshot_batch_size"]),
+            "snapshot_batch_size",
+        )
+        start, stop = _partition_spatial_axis(
+            source.spatial_shape[0], process_rank, world_size
+        )
+        instance._local_spatial_slice = slice(start, stop)
+        instance._mean = instance._mean_result() if instance._subtract_mean else None
+        return instance
+
     def __str__(self) -> str:
         size, unit = format_byte_size(self.required_memory)
         ms = (
             f"SVD of a {self._rows}x{self._cols} data matrix",
             f"Selected/optimal rank: {self.rank}/{self.opt_rank}",
-            f"data type: {self.U.dtype} ({self.U.element_size()}b)",
+            f"data type: {self.V.dtype} ({self.V.element_size()}b)",
             "truncated SVD size: {:1.4f}{:s}".format(size, unit),
         )
         return "\n".join(ms)

--- a/flowtorch/data/dataloader.py
+++ b/flowtorch/data/dataloader.py
@@ -56,6 +56,40 @@ class Dataloader(ABC):
         """
         pass
 
+    def load_snapshot_slice(
+        self,
+        field_name: Union[List[str], str],
+        time: Union[List[str], str],
+        spatial_slice: slice,
+    ) -> Union[List[Tensor], Tensor]:
+        """Load a slice along the first spatial dimension.
+
+        The default implementation preserves compatibility with existing
+        loaders by loading the requested snapshots first and slicing them in
+        memory. Array-backed loaders may override this method to avoid reading
+        values outside ``spatial_slice``.
+
+        :param field_name: name of one or more fields
+        :param time: one or more snapshot times
+        :param spatial_slice: slice along the first tensor dimension
+        :return: sliced field tensor or list of tensors
+        """
+        loaded = self.load_snapshot(field_name, time)
+        if isinstance(loaded, list):
+            return [field[spatial_slice] for field in loaded]
+        return loaded[spatial_slice]
+
+    def snapshot_shape(self, field_name: str, time: str) -> Sequence[int]:
+        """Return the shape of one field snapshot.
+
+        Loaders with inexpensive metadata access should override this fallback,
+        which reads one snapshot.
+        """
+        loaded = self.load_snapshot(field_name, time)
+        if isinstance(loaded, list):
+            raise RuntimeError("a single field must return one tensor")
+        return tuple(loaded.shape)
+
     @property
     @abstractmethod
     def write_times(self) -> List[str]:

--- a/flowtorch/data/foam_numpy_dataloader.py
+++ b/flowtorch/data/foam_numpy_dataloader.py
@@ -460,6 +460,58 @@ class FOAMNumpyDataloader(Dataloader):
                 offset += processor_size
         return result[..., 0] if len(snapshots) == 1 else result
 
+    def _load_field_slice(
+        self, field: str, snapshots: List[_Snapshot], spatial_slice: slice
+    ) -> pt.Tensor:
+        """Load a contiguous global cell slice from memory-mapped arrays."""
+        for snapshot in snapshots:
+            if field not in snapshot.batch.field_files:
+                raise ValueError(
+                    f"Field {field!r} is not available at time "
+                    f"{_format_time(snapshot.time)!r}"
+                )
+        component_shape = snapshots[0].batch.field_shapes[field]
+        if any(
+            snapshot.batch.field_shapes[field] != component_shape
+            for snapshot in snapshots[1:]
+        ):
+            raise ValueError(f"Component shape changes across snapshots for {field!r}")
+        n_cells = sum(self._processor_sizes)
+        start, stop, step = spatial_slice.indices(n_cells)
+        if step != 1:
+            raise ValueError("spatial_slice must have unit stride")
+        result = pt.empty(
+            (stop - start, *component_shape, len(snapshots)), dtype=self._dtype
+        )
+        grouped: Dict[Path, List[Tuple[int, _Snapshot]]] = {}
+        for output_index, snapshot in enumerate(snapshots):
+            grouped.setdefault(snapshot.batch.path, []).append((output_index, snapshot))
+        for entries in grouped.values():
+            batch = entries[0][1].batch
+            global_offset = 0
+            for processor_size, path in zip(
+                batch.processor_sizes, batch.field_files[field]
+            ):
+                overlap_start = max(start, global_offset)
+                overlap_stop = min(stop, global_offset + processor_size)
+                if overlap_start < overlap_stop:
+                    local_start = overlap_start - global_offset
+                    local_stop = overlap_stop - global_offset
+                    target_start = overlap_start - start
+                    target_stop = overlap_stop - start
+                    array = self._load_array(path, mmap=True)
+                    for output_index, snapshot in entries:
+                        values = np.array(
+                            array[local_start:local_stop, ..., snapshot.index],
+                            copy=True,
+                            order="C",
+                        )
+                        result[target_start:target_stop, ..., output_index].copy_(
+                            pt.as_tensor(values, dtype=self._dtype)
+                        )
+                global_offset += processor_size
+        return result[..., 0] if len(snapshots) == 1 else result
+
     def load_snapshot(
         self, field_name: Union[List[str], str], time: Union[List[str], str]
     ) -> Union[List[pt.Tensor], pt.Tensor]:
@@ -471,6 +523,32 @@ class FOAMNumpyDataloader(Dataloader):
         snapshots = [self._snapshot_at(value) for value in times]
         loaded = [self._load_field(field, snapshots) for field in fields]
         return loaded if isinstance(field_name, list) else loaded[0]
+
+    def load_snapshot_slice(
+        self,
+        field_name: Union[List[str], str],
+        time: Union[List[str], str],
+        spatial_slice: slice,
+    ) -> Union[List[pt.Tensor], pt.Tensor]:
+        """Load a first-axis slice directly from processor NumPy arrays."""
+        check_list_or_str(field_name, "field_name")
+        check_list_or_str(time, "time")
+        fields = field_name if isinstance(field_name, list) else [field_name]
+        times = time if isinstance(time, list) else [time]
+        snapshots = [self._snapshot_at(value) for value in times]
+        loaded = [
+            self._load_field_slice(field, snapshots, spatial_slice) for field in fields
+        ]
+        if isinstance(time, list) and len(time) == 1:
+            loaded = [value.unsqueeze(-1) for value in loaded]
+        return loaded if isinstance(field_name, list) else loaded[0]
+
+    def snapshot_shape(self, field_name: str, time: str) -> tuple[int, ...]:
+        """Return a field shape from batch metadata."""
+        snapshot = self._snapshot_at(time)
+        if field_name not in snapshot.batch.field_shapes:
+            raise ValueError(f"Field {field_name!r} is not available at time {time!r}")
+        return (sum(self._processor_sizes), *snapshot.batch.field_shapes[field_name])
 
     @property
     def write_times(self) -> List[str]:

--- a/flowtorch/data/hdf5_file.py
+++ b/flowtorch/data/hdf5_file.py
@@ -110,6 +110,18 @@ class HDF5Dataloader(Dataloader):
             dtype=self._dtype,
         ).squeeze()
 
+    def _load_single_snapshot_slice(
+        self, field_name: str, time: str, spatial_slice: slice
+    ) -> pt.Tensor:
+        """Load a first-axis slice directly from an HDF5 dataset."""
+        values = pt.tensor(
+            self._file[f"{VAR_GROUP}/{time}/{field_name}"][spatial_slice],
+            dtype=self._dtype,
+        )
+        return (
+            values.squeeze(-1) if values.ndim > 1 and values.shape[-1] == 1 else values
+        )
+
     def load_snapshot(
         self, field_name: Union[List[str], str], time: Union[List[str], str]
     ) -> Union[List[pt.Tensor], pt.Tensor]:
@@ -136,6 +148,37 @@ class HDF5Dataloader(Dataloader):
                 )
             else:
                 return self._load_single_snapshot(field_name, time)
+
+    def load_snapshot_slice(
+        self,
+        field_name: Union[List[str], str],
+        time: Union[List[str], str],
+        spatial_slice: slice,
+    ) -> Union[List[pt.Tensor], pt.Tensor]:
+        """Load one or more fields using direct first-axis HDF5 slicing."""
+        check_list_or_str(field_name, "field_name")
+        check_list_or_str(time, "time")
+        fields = field_name if isinstance(field_name, list) else [field_name]
+        times = time if isinstance(time, list) else [time]
+        loaded = [
+            _preallocate_time_series(
+                partial(
+                    self._load_single_snapshot_slice,
+                    name,
+                    spatial_slice=spatial_slice,
+                ),
+                times,
+            )
+            for name in fields
+        ]
+        if not isinstance(time, list):
+            loaded = [value[..., 0] for value in loaded]
+        return loaded if isinstance(field_name, list) else loaded[0]
+
+    def snapshot_shape(self, field_name: str, time: str) -> tuple[int, ...]:
+        """Return a variable dataset shape without loading it."""
+        shape = tuple(self._file[f"{VAR_GROUP}/{time}/{field_name}"].shape)
+        return shape[:-1] if len(shape) > 1 and shape[-1] == 1 else shape
 
     @property
     def write_times(self) -> List[str]:

--- a/tests/analysis/test_distributed_svd.py
+++ b/tests/analysis/test_distributed_svd.py
@@ -1,0 +1,158 @@
+"""Multi-process tests for spatially distributed TSQR SVD."""
+
+import os
+
+import pytest
+import torch as pt
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+from flowtorch.analysis import DistributedExecution, PAMSPOD, SVD, subspace_similarity
+from flowtorch.analysis.spod import mode_similarity
+from flowtorch.analysis.state_vector import (
+    FieldSpec,
+    StateVectorLayout,
+    StateVectorSource,
+)
+
+pytestmark = pytest.mark.integration
+
+
+class _DistributedMatrixSource(StateVectorSource):
+    def __init__(self, data, weight=None):
+        self.data = data
+        self.weight = weight
+        self._layout = StateVectorLayout((FieldSpec("q"),), (data.shape[0],))
+
+    @property
+    def n_snapshots(self):
+        return self.data.shape[1]
+
+    @property
+    def layout(self):
+        return self._layout
+
+    def read(self, spatial_slice, snapshot_slice):
+        return self.data[spatial_slice, snapshot_slice]
+
+    def read_weight(self, spatial_slice):
+        return None if self.weight is None else self.weight[spatial_slice]
+
+
+def _worker(rank, world_size, store_path):
+    dist.init_process_group(
+        "gloo",
+        init_method=f"file://{store_path}",
+        rank=rank,
+        world_size=world_size,
+    )
+    try:
+        pt.manual_seed(12)
+        data = pt.rand((17, 5), dtype=pt.float64)
+        weight = pt.linspace(0.5, 1.5, data.shape[0], dtype=data.dtype)
+        execution = DistributedExecution(root_rank=1)
+        svd = SVD(
+            _DistributedMatrixSource(data, weight),
+            rank=4,
+            subtract_mean=True,
+            spatial_batch_size=3,
+            snapshot_batch_size=2,
+            execution=execution,
+        )
+        direct = SVD(
+            data - data.mean(dim=1, keepdim=True),
+            rank=4,
+            mode="svd",
+            weight=weight,
+        )
+        pt.testing.assert_close(svd.s, direct.s)
+        gathered_modes = svd.U.gather(root_rank=1)
+        gathered_reconstruction = svd.reconstruct().gather(root_rank=1)
+        if rank == 1:
+            assert gathered_modes is not None
+            assert gathered_reconstruction is not None
+            pt.testing.assert_close(
+                subspace_similarity(gathered_modes, direct.U, ranks=4, weight=weight),
+                pt.ones(1, dtype=data.dtype),
+            )
+            pt.testing.assert_close(gathered_reconstruction, direct.reconstruct())
+        else:
+            assert gathered_modes is None
+            assert gathered_reconstruction is None
+
+        spod = PAMSPOD.from_svd(
+            svd,
+            dt=0.1,
+            adaptive=False,
+            max_tapers=3,
+            keep_n_modes=2,
+        )
+        direct_spod = PAMSPOD(
+            data,
+            dt=0.1,
+            rank=4,
+            weight=weight,
+            adaptive=False,
+            max_tapers=3,
+            keep_n_modes=2,
+        )
+        pt.testing.assert_close(spod.eigvals, direct_spod.eigvals)
+        gathered_mode = spod.get_mode(2).gather(root_rank=1)
+        if rank == 1:
+            assert gathered_mode is not None
+            similarity = mode_similarity(
+                gathered_mode.unsqueeze(-1),
+                direct_spod.get_mode(2).unsqueeze(-1),
+            )
+            pt.testing.assert_close(similarity, pt.ones_like(similarity))
+        else:
+            assert gathered_mode is None
+
+        initial = _DistributedMatrixSource(data[:, :3])
+        appended = _DistributedMatrixSource(data[:, 3:])
+        updated = SVD(
+            initial,
+            rank=3,
+            spatial_batch_size=3,
+            snapshot_batch_size=2,
+            execution=execution,
+        )
+        updated.update(appended)
+        direct_updated = SVD(data, rank=3, mode="svd")
+        pt.testing.assert_close(updated.s, direct_updated.s)
+        gathered_updated = updated.U.gather(root_rank=1)
+        if rank == 1:
+            assert gathered_updated is not None
+            pt.testing.assert_close(
+                subspace_similarity(gathered_updated, direct_updated.U, ranks=3),
+                pt.ones(1, dtype=data.dtype),
+            )
+        else:
+            assert gathered_updated is None
+
+        checkpoint_path = f"{store_path}-svd.pt"
+        updated.save(checkpoint_path)
+        restored = SVD.load(
+            checkpoint_path,
+            source=_DistributedMatrixSource(data),
+            execution=execution,
+        )
+        pt.testing.assert_close(restored.s, updated.s)
+        pt.testing.assert_close(restored.V, updated.V)
+        gathered_restored = restored.reconstruct().gather(root_rank=1)
+        gathered_original = updated.reconstruct().gather(root_rank=1)
+        if rank == 1:
+            assert gathered_restored is not None
+            assert gathered_original is not None
+            pt.testing.assert_close(gathered_restored, gathered_original)
+        else:
+            assert gathered_restored is None
+            assert gathered_original is None
+    finally:
+        dist.destroy_process_group()
+
+
+@pytest.mark.skipif(not dist.is_available(), reason="torch.distributed unavailable")
+def test_spatially_distributed_tsqr_matches_serial(tmp_path):
+    store_path = os.fspath(tmp_path / "distributed-svd-store")
+    mp.spawn(_worker, args=(3, store_path), nprocs=3, join=True)

--- a/tests/analysis/test_spod.py
+++ b/tests/analysis/test_spod.py
@@ -3,6 +3,7 @@
 import pytest
 from pytest import raises
 import torch as pt
+from flowtorch.analysis import SVD
 from flowtorch.analysis.spod import (
     AMSPOD,
     PAMSPOD,
@@ -11,6 +12,30 @@ from flowtorch.analysis.spod import (
     _free_memory,
     mode_similarity,
 )
+from flowtorch.analysis.state_vector import (
+    FieldSpec,
+    StateVectorLayout,
+    StateVectorSource,
+)
+
+
+class _SPODSource(StateVectorSource):
+    def __init__(self, data):
+        self.data = data
+        self.calls = []
+        self._layout = StateVectorLayout((FieldSpec("q"),), (data.shape[0],))
+
+    @property
+    def n_snapshots(self):
+        return self.data.shape[1]
+
+    @property
+    def layout(self):
+        return self._layout
+
+    def read(self, spatial_slice, snapshot_slice):
+        self.calls.append((spatial_slice, snapshot_slice))
+        return self.data[spatial_slice, snapshot_slice]
 
 
 def test_prepare_sqrt_weight():
@@ -499,3 +524,56 @@ def test_PAMSPOD():
     reduced_modes = spod._modes[:, :, 0].T
     expected_similarity = mode_similarity(reduced_modes, reduced_modes)
     pt.testing.assert_close(spod.mode_similarity(), expected_similarity)
+
+
+def test_PAMSPOD_from_existing_svd_reuses_temporal_factors():
+    pt.manual_seed(13)
+    data = pt.rand((31, 8), dtype=pt.float64)
+    source = _SPODSource(data)
+    svd = SVD(
+        source,
+        rank=5,
+        subtract_mean=True,
+        spatial_batch_size=6,
+        snapshot_batch_size=3,
+    )
+    source.calls.clear()
+
+    spod = PAMSPOD.from_svd(
+        svd,
+        dt=0.2,
+        adaptive=False,
+        max_tapers=3,
+        keep_n_modes=2,
+    )
+
+    assert source.calls == []
+    assert spod.svd is svd
+    assert spod.eigvals.shape == (5, 3)
+    mode = spod.get_mode(2).materialize_local()
+    assert mode.shape == (31,)
+    assert source.calls
+
+
+def test_source_PAMSPOD_returns_lazy_split_reconstruction():
+    pt.manual_seed(14)
+    data = pt.rand((29, 8), dtype=pt.float64)
+    source = _SPODSource(data)
+    spod = PAMSPOD(
+        source,
+        dt=0.1,
+        rank=5,
+        adaptive=False,
+        max_tapers=3,
+        keep_n_modes=2,
+        spatial_batch_size=7,
+        snapshot_batch_size=2,
+    )
+
+    reconstruction = spod.partial_reconstruction(
+        1, 3, n_modes=1, n_snapshots=4, add_mean=True
+    )
+    fields = reconstruction.materialize_local(split=True)
+
+    assert fields["q"].shape == (29, 4)
+    assert bool(pt.isfinite(fields["q"]).all())

--- a/tests/analysis/test_state_vector.py
+++ b/tests/analysis/test_state_vector.py
@@ -1,0 +1,216 @@
+"""Tests for lazy physical state-vector construction."""
+
+import pytest
+import torch as pt
+from h5py import File
+
+from flowtorch.analysis.svd import SVD
+from flowtorch.analysis.state_vector import (
+    DataloaderStateVectorSource,
+    FieldSpec,
+    StateVectorLayout,
+    StateVectorResult,
+)
+from flowtorch.data.dataloader import Dataloader
+from flowtorch.data.hdf5_file import HDF5Dataloader
+
+
+class _Loader(Dataloader):
+    def __init__(self):
+        time = pt.arange(4, dtype=pt.float64)
+        self.data = {
+            "p": pt.arange(5, dtype=pt.float64)[:, None] + time,
+            "U": pt.stack(
+                (
+                    pt.arange(5, dtype=pt.float64)[:, None] + time,
+                    10.0 + time.expand(5, -1),
+                ),
+                dim=1,
+            ),
+        }
+        self.slice_calls = []
+
+    def load_snapshot(self, field_name, time):
+        fields = field_name if isinstance(field_name, list) else [field_name]
+        times = time if isinstance(time, list) else [time]
+        indices = [int(value) for value in times]
+        loaded = [self.data[name][..., indices] for name in fields]
+        if not isinstance(time, list):
+            loaded = [value[..., 0] for value in loaded]
+        return loaded if isinstance(field_name, list) else loaded[0]
+
+    def load_snapshot_slice(self, field_name, time, spatial_slice):
+        self.slice_calls.append(spatial_slice)
+        loaded = self.load_snapshot(field_name, time)
+        if isinstance(loaded, list):
+            return [value[spatial_slice] for value in loaded]
+        return loaded[spatial_slice]
+
+    def snapshot_shape(self, field_name, time):
+        return self.data[field_name].shape[:-1]
+
+    @property
+    def write_times(self):
+        return [str(index) for index in range(4)]
+
+    @property
+    def field_names(self):
+        return {time: ["p", "U"] for time in self.write_times}
+
+    @property
+    def vertices(self):
+        return pt.arange(5)[:, None]
+
+    @property
+    def weights(self):
+        return pt.ones(5)
+
+
+def test_layout_uses_one_factor_per_field_and_round_trips_components():
+    layout = StateVectorLayout(
+        (FieldSpec("U", (2,), ("u", "v")), FieldSpec("p")),
+        (3,),
+        {"U": 2.0, "p": 10.0},
+    )
+    fields = {
+        "U": pt.arange(18, dtype=pt.float64).reshape(3, 2, 3),
+        "p": pt.arange(9, dtype=pt.float64).reshape(3, 3),
+    }
+
+    state = layout.pack(fields)
+    assert state.shape == (9, 3)
+    pt.testing.assert_close(state[:3], fields["U"][:, 0] / 2.0)
+    pt.testing.assert_close(state[3:6], fields["U"][:, 1] / 2.0)
+    restored = layout.split(state)
+    pt.testing.assert_close(restored["U"], fields["U"])
+    pt.testing.assert_close(restored["p"], fields["p"])
+
+
+def test_layout_round_trips_tensor_components():
+    layout = StateVectorLayout((FieldSpec("stress", (2, 2)),), (3,))
+    field = pt.arange(36, dtype=pt.float64).reshape(3, 2, 2, 3)
+
+    restored = layout.split(layout.pack({"stress": field}))
+
+    pt.testing.assert_close(restored["stress"], field)
+
+
+def test_normalization_requires_exactly_one_scalar_per_field():
+    fields = (FieldSpec("U", (2,)), FieldSpec("p"))
+
+    with pytest.raises(ValueError, match="exactly one factor per field"):
+        StateVectorLayout(fields, (3,), {})
+    with pytest.raises(ValueError, match="real scalars"):
+        StateVectorLayout(fields, (3,), {"U": [1.0, 2.0], "p": 1.0})
+
+
+def test_result_keeps_flat_values_normalized_and_split_values_physical():
+    layout = StateVectorLayout(
+        (FieldSpec("U", (2,)), FieldSpec("p")),
+        (4,),
+        {"U": 2.0, "p": 5.0},
+    )
+    physical = {
+        "U": pt.arange(8, dtype=pt.float64).reshape(4, 2),
+        "p": pt.arange(4, dtype=pt.float64),
+    }
+
+    def produce(spatial_slice):
+        shape = (spatial_slice.stop - spatial_slice.start,)
+        values = {name: value[spatial_slice] for name, value in physical.items()}
+        return layout.pack(values, spatial_shape=shape)
+
+    result = StateVectorResult(layout, slice(0, 4), (), produce, 2)
+
+    pt.testing.assert_close(result.materialize_local(), layout.pack(physical))
+    split = result.materialize_local(split=True)
+    pt.testing.assert_close(split["U"], physical["U"])
+    pt.testing.assert_close(split["p"], physical["p"])
+
+
+def test_dataloader_source_reads_only_requested_chunks():
+    loader = _Loader()
+    source = DataloaderStateVectorSource(
+        loader,
+        (FieldSpec("U", (2,), ("u", "v")), FieldSpec("p")),
+        normalization={"U": 2.0, "p": 4.0},
+    )
+
+    state = source.read(slice(1, 4), slice(1, 3))
+
+    assert state.shape == (9, 2)
+    assert loader.slice_calls == [slice(1, 4)]
+    restored = source.layout.split(state, spatial_shape=(3,))
+    pt.testing.assert_close(restored["U"], loader.data["U"][1:4, :, 1:3])
+    pt.testing.assert_close(restored["p"], loader.data["p"][1:4, 1:3])
+
+
+def test_fitted_rms_uses_one_vector_magnitude_factor():
+    loader = _Loader()
+    source = DataloaderStateVectorSource(
+        loader,
+        (FieldSpec("U", (2,), ("u", "v")), FieldSpec("p")),
+        normalization="rms",
+        spatial_weight=loader.weights,
+    )
+
+    source.fit_normalization(slice(0, 5), 2, 2)
+
+    velocity = loader.data["U"]
+    pressure = loader.data["p"]
+    velocity_fluctuation = velocity - velocity.mean(dim=-1, keepdim=True)
+    pressure_fluctuation = pressure - pressure.mean(dim=-1, keepdim=True)
+    expected_velocity = velocity_fluctuation.square().sum() / (4 * 5)
+    expected_pressure = pressure_fluctuation.square().sum() / (4 * 5)
+    factors = source.layout.normalization_factors
+    pt.testing.assert_close(
+        pt.tensor(factors["U"] ** 2, dtype=pt.float64), expected_velocity
+    )
+    pt.testing.assert_close(
+        pt.tensor(factors["p"] ** 2, dtype=pt.float64), expected_pressure
+    )
+
+
+def test_checkpoint_restores_fitted_rms_without_scanning_snapshots(tmp_path):
+    fields = (FieldSpec("U", (2,), ("u", "v")), FieldSpec("p"))
+    source = DataloaderStateVectorSource(_Loader(), fields, normalization="rms")
+    svd = SVD(source, rank=3, spatial_batch_size=2, snapshot_batch_size=2)
+    path = tmp_path / "fitted-rms-svd.pt"
+    svd.save(path)
+    restored_loader = _Loader()
+    restored_source = DataloaderStateVectorSource(
+        restored_loader, fields, normalization="rms"
+    )
+
+    restored = SVD.load(path, source=restored_source)
+
+    assert restored_loader.slice_calls == []
+    assert restored_source.normalization_fitted
+    assert (
+        restored_source.layout.normalization_factors
+        == source.layout.normalization_factors
+    )
+    pt.testing.assert_close(restored.s, svd.s)
+
+
+def test_hdf5_loader_reads_spatial_slice_directly(tmp_path):
+    path = tmp_path / "fields.h5"
+    with File(path, "w") as output:
+        variables = output.create_group("variable")
+        for index, time in enumerate(("0", "1")):
+            group = variables.create_group(time)
+            group.create_dataset("p", data=(pt.arange(6) + index).numpy().reshape(6, 1))
+            group.create_dataset(
+                "U", data=(pt.arange(18) + index).numpy().reshape(6, 3)
+            )
+        constants = output.create_group("constant")
+        constants.create_dataset("centers", data=pt.zeros((6, 3)).numpy())
+        constants.create_dataset("volumes", data=pt.ones(6).numpy())
+
+    loader = HDF5Dataloader(str(path), dtype=pt.float64)
+    pressure, velocity = loader.load_snapshot_slice(["p", "U"], ["0", "1"], slice(2, 5))
+
+    assert pressure.shape == (3, 2)
+    assert velocity.shape == (3, 3, 2)
+    assert loader.snapshot_shape("p", "0") == (6,)
+    assert loader.snapshot_shape("U", "0") == (6, 3)

--- a/tests/analysis/test_svd.py
+++ b/tests/analysis/test_svd.py
@@ -10,6 +10,34 @@ from flowtorch.analysis.svd import (
     pod_subspace_data_dependency,
     subspace_similarity,
 )
+from flowtorch.analysis.state_vector import (
+    FieldSpec,
+    StateVectorLayout,
+    StateVectorSource,
+)
+
+
+class _MatrixSource(StateVectorSource):
+    def __init__(self, data, weight=None):
+        self.data = data
+        self._layout = StateVectorLayout((FieldSpec("q"),), (data.shape[0],))
+        self._weight = weight
+        self.calls = []
+
+    @property
+    def n_snapshots(self):
+        return self.data.shape[1]
+
+    @property
+    def layout(self):
+        return self._layout
+
+    def read(self, spatial_slice, snapshot_slice):
+        self.calls.append((spatial_slice, snapshot_slice))
+        return self.data[spatial_slice, snapshot_slice]
+
+    def read_weight(self, spatial_slice):
+        return None if self._weight is None else self._weight[spatial_slice]
 
 
 def test_subspace_similarity_is_basis_invariant():
@@ -168,6 +196,135 @@ class TestSVD:
             _ = SVD(dm.unsqueeze(-1))
         with pytest.raises(ValueError):
             _ = SVD(dm, mode="abc")
+
+    def test_source_backed_tsqr_reconstructs_out_of_core(self):
+        pt.manual_seed(7)
+        data = pt.rand((41, 6), dtype=pt.float64)
+        source = _MatrixSource(data)
+
+        svd = SVD(
+            source,
+            rank=6,
+            spatial_batch_size=7,
+            snapshot_batch_size=2,
+        )
+
+        assert svd.mode == "tsqr"
+        assert svd.U.global_shape == (41, 6)
+        pt.testing.assert_close(svd.reconstruct().materialize_local(), data)
+        assert all(call[0].stop - call[0].start <= 7 for call in source.calls)
+        assert all(call[1].stop - call[1].start <= 2 for call in source.calls)
+
+    def test_source_backed_centered_weighted_tsqr(self):
+        pt.manual_seed(8)
+        data = pt.rand((37, 5), dtype=pt.float64)
+        weight = pt.linspace(1.0, 2.0, data.shape[0], dtype=pt.float64)
+        source = _MatrixSource(data, weight)
+
+        svd = SVD(source, rank=4, subtract_mean=True, spatial_batch_size=8)
+        modes = svd.U.materialize_local()
+        mean = svd.mean.materialize_local()
+
+        pt.testing.assert_close(mean, data.mean(dim=1))
+        pt.testing.assert_close(
+            modes.conj().T @ (modes * weight.unsqueeze(-1)), pt.eye(4, dtype=data.dtype)
+        )
+        pt.testing.assert_close(
+            svd.reconstruct().materialize_local(),
+            data - data.mean(dim=1, keepdim=True),
+        )
+
+    def test_source_backed_incremental_update_matches_direct_svd(self):
+        pt.manual_seed(9)
+        first = pt.rand((43, 4), dtype=pt.float64)
+        second = pt.rand((43, 3), dtype=pt.float64)
+        svd = SVD(_MatrixSource(first), rank=4, spatial_batch_size=9)
+
+        svd.update(_MatrixSource(second))
+
+        combined = pt.cat((first, second), dim=1)
+        direct = SVD(combined, rank=4, mode="svd")
+        pt.testing.assert_close(svd.s, direct.s)
+        pt.testing.assert_close(
+            subspace_similarity(svd.U.materialize_local(), direct.U, ranks=4),
+            pt.ones(1, dtype=first.dtype),
+        )
+
+    def test_centered_update_recomputes_with_combined_mean(self):
+        pt.manual_seed(10)
+        first = pt.rand((31, 4), dtype=pt.float64)
+        second = 2.0 + pt.rand((31, 2), dtype=pt.float64)
+        svd = SVD(
+            _MatrixSource(first), rank=5, subtract_mean=True, spatial_batch_size=6
+        )
+
+        svd.update(_MatrixSource(second))
+
+        combined = pt.cat((first, second), dim=1)
+        centered = combined - combined.mean(dim=1, keepdim=True)
+        direct = SVD(centered, rank=4, mode="svd")
+        pt.testing.assert_close(
+            svd.reconstruct().materialize_local(),
+            direct.reconstruct(),
+        )
+
+    def test_tensor_checkpoint_round_trip(self, tmp_path):
+        pt.manual_seed(14)
+        data = pt.rand((18, 5), dtype=pt.float64)
+        weight = pt.linspace(1.0, 2.0, data.shape[0], dtype=data.dtype)
+        svd = SVD(
+            data,
+            rank=4,
+            mode="svd",
+            weight=weight,
+            subtract_mean=True,
+        )
+        path = tmp_path / "tensor-svd.pt"
+
+        svd.save(path)
+        restored = SVD.load(path)
+
+        assert restored.rank == svd.rank
+        assert restored.opt_rank == svd.opt_rank
+        assert restored.mode == svd.mode
+        pt.testing.assert_close(restored.U, svd.U)
+        pt.testing.assert_close(restored.s_full, svd.s_full)
+        pt.testing.assert_close(restored.V, svd.V)
+        pt.testing.assert_close(restored.mean, svd.mean)
+        pt.testing.assert_close(restored.reconstruct(), svd.reconstruct())
+
+    def test_source_checkpoint_reconnects_without_reading_data(self, tmp_path):
+        pt.manual_seed(15)
+        data = pt.rand((29, 6), dtype=pt.float64)
+        source = _MatrixSource(data)
+        svd = SVD(
+            source,
+            rank=5,
+            subtract_mean=True,
+            spatial_batch_size=7,
+            snapshot_batch_size=2,
+        )
+        path = tmp_path / "source-svd.pt"
+        svd.save(path)
+        restored_source = _MatrixSource(data)
+
+        restored = SVD.load(path, source=restored_source)
+
+        assert restored_source.calls == []
+        pt.testing.assert_close(restored.s_full, svd.s_full)
+        pt.testing.assert_close(restored.V, svd.V)
+        pt.testing.assert_close(
+            restored.reconstruct().materialize_local(),
+            data - data.mean(dim=1, keepdim=True),
+        )
+
+    def test_source_checkpoint_rejects_incompatible_source(self, tmp_path):
+        svd = SVD(_MatrixSource(pt.rand((12, 4))), rank=3)
+        path = tmp_path / "source-svd.pt"
+        svd.save(path)
+
+        with pytest.raises(ValueError, match="incompatible"):
+            SVD.load(path, source=_MatrixSource(pt.rand((13, 4))))
 
     def test_truncated_factors_use_compact_storage(self):
         M, N, rank = 100, 15, 3

--- a/tests/data/test_foam_numpy_dataloader.py
+++ b/tests/data/test_foam_numpy_dataloader.py
@@ -140,6 +140,39 @@ def test_load_multiple_times_fields_and_dtype(foam_numpy_output: Path):
     assert pt.equal(velocity[:, 2], pressure + 200.0)
 
 
+def test_load_snapshot_slice_reads_global_processor_interval(
+    foam_numpy_output: Path,
+):
+    loader = FOAMNumpyDataloader(str(foam_numpy_output), dtype=pt.float64)
+
+    pressure, velocity = loader.load_snapshot_slice(
+        ["p", "U"], ["0.4", "0.1"], slice(1, 3)
+    )
+
+    assert pressure.shape == (2, 2)
+    assert velocity.shape == (2, 3, 2)
+    pt.testing.assert_close(
+        pressure,
+        loader.load_snapshot("p", ["0.4", "0.1"])[1:3],
+    )
+    pt.testing.assert_close(
+        velocity,
+        loader.load_snapshot("U", ["0.4", "0.1"])[1:3],
+    )
+    assert loader.snapshot_shape("U", "0.1") == (3, 3)
+
+
+def test_load_snapshot_slice_preserves_explicit_single_time_axis(
+    foam_numpy_output: Path,
+):
+    loader = FOAMNumpyDataloader(str(foam_numpy_output), dtype=pt.float64)
+
+    pressure = loader.load_snapshot_slice("p", ["0.1"], slice(1, 3))
+
+    assert pressure.shape == (2, 1)
+    pt.testing.assert_close(pressure[..., 0], loader.load_snapshot("p", "0.1")[1:3])
+
+
 def test_load_geometry_and_direct_segment_path(foam_numpy_output: Path):
     loader = FOAMNumpyDataloader(str(foam_numpy_output / "0"))
 


### PR DESCRIPTION
## Summary
- add lazy normalized multi-field state vectors with component-aware splitting
- add shared-memory and spatially distributed out-of-core TSQR SVD, incremental updates, and versioned checkpoints
- let PAMSPOD consume lazy sources or reuse an existing SVD
- add direct spatial slicing for HDF5 and FOAM NumPy loaders
- document CPU/GPU, Slurm, batching, reconstruction, update, and save/load workflows

## Validation
- tox -e py310
- distributed SVD/PAMSPOD integration test with 3 Gloo ranks
- tox -e format-check
- tox -e lint
- tox -e type-check
- tox -e docs
- tox -e package